### PR TITLE
export keyword to SyntaxKind

### DIFF
--- a/src/HlslTools.Tests/Parser/DeclarationParsingTests.cs
+++ b/src/HlslTools.Tests/Parser/DeclarationParsingTests.cs
@@ -275,6 +275,39 @@ namespace HlslTools.Tests.Parser
         }
 
         [Test]
+        public void TestExportFunctionDefinition()
+        {
+            var text = "export void Foo(int a) { return; }";
+            var file = ParseFile(text);
+
+            Assert.NotNull(file);
+            Assert.AreEqual(1, file.Declarations.Count);
+            Assert.AreEqual(text, file.ToString());
+            Assert.AreEqual(0, file.GetDiagnostics().Count());
+
+            Assert.AreEqual(SyntaxKind.FunctionDefinition, file.Declarations[0].Kind);
+            var fs = (FunctionDefinitionSyntax)file.Declarations[0];
+            Assert.AreEqual(1, fs.Modifiers.Count);
+            Assert.AreEqual(SyntaxKind.ExportKeyword, fs.Modifiers[0].Kind);
+            Assert.NotNull(fs.ReturnType);
+            Assert.AreEqual("void", fs.ReturnType.ToString());
+            Assert.AreEqual("Foo", fs.Name.ToString());
+            Assert.NotNull(fs.ParameterList.OpenParenToken);
+            Assert.False(fs.ParameterList.OpenParenToken.IsMissing);
+            Assert.AreEqual(1, fs.ParameterList.Parameters.Count);
+            var fp = fs.ParameterList.Parameters[0];
+            Assert.AreEqual("int", fp.Type.ToString());
+            Assert.AreEqual("a", fp.Declarator.Identifier.ToString());
+            Assert.NotNull(fs.ParameterList.CloseParenToken);
+            Assert.False(fs.ParameterList.CloseParenToken.IsMissing);
+            Assert.NotNull(fs.Body);
+            Assert.NotNull(fs.Body.OpenBraceToken);
+            Assert.AreEqual(1, fs.Body.Statements.Count);
+            Assert.NotNull(fs.Body.CloseBraceToken);
+            Assert.Null(fs.SemicolonToken);
+        }
+
+        [Test]
         public void TestSamplerStateInitializer()
         {
             var text = "SamplerState MySamplerState { MinFilter = <point>; MagFilter = linear; MipFilter = anistropic; AlphaBlendEnable = 16 > 8; };";

--- a/src/HlslTools/Syntax/SyntaxFacts.cs
+++ b/src/HlslTools/Syntax/SyntaxFacts.cs
@@ -184,6 +184,8 @@ namespace HlslTools.Syntax
                     return "static";
                 case SyntaxKind.ConstKeyword:
                     return "const";
+                case SyntaxKind.ExportKeyword:
+                    return "export";
                 case SyntaxKind.InlineKeyword:
                     return "inline";
                 case SyntaxKind.VolatileKeyword:
@@ -968,6 +970,7 @@ namespace HlslTools.Syntax
             {
                 case SyntaxKind.ClassKeyword:
                 case SyntaxKind.ConstKeyword:
+                case SyntaxKind.ExportKeyword:
                 case SyntaxKind.ExternKeyword:
                 case SyntaxKind.InlineKeyword:
                 case SyntaxKind.InterfaceKeyword:
@@ -1339,6 +1342,7 @@ namespace HlslTools.Syntax
                 case SyntaxKind.Double4x3Keyword:
                 case SyntaxKind.Double4x4Keyword:
                 case SyntaxKind.ElseKeyword:
+                case SyntaxKind.ExportKeyword:
                 case SyntaxKind.ExternKeyword:
                 case SyntaxKind.FalseKeyword:
                 case SyntaxKind.FloatKeyword:
@@ -1781,6 +1785,8 @@ namespace HlslTools.Syntax
                     return SyntaxKind.Double4x4Keyword;
                 case "else":
                     return SyntaxKind.ElseKeyword;
+                case "export":
+                    return SyntaxKind.ExportKeyword;
                 case "extern":
                     return SyntaxKind.ExternKeyword;
                 case "float":
@@ -2217,6 +2223,7 @@ namespace HlslTools.Syntax
                 case SyntaxKind.ColumnMajorKeyword:
                     return true;
 
+                case SyntaxKind.ExportKeyword:
                 case SyntaxKind.ExternKeyword:
                 case SyntaxKind.InlineKeyword:
                 case SyntaxKind.PreciseKeyword:

--- a/src/HlslTools/Syntax/SyntaxKind.cs
+++ b/src/HlslTools/Syntax/SyntaxKind.cs
@@ -70,6 +70,7 @@ namespace HlslTools.Syntax
         Double4x4Keyword,
         ElseKeyword,
         ErrorKeyword,
+        ExportKeyword,
         ExternKeyword,
         FloatKeyword,
         Float1Keyword,


### PR DESCRIPTION
Hello

As mentioned in https://github.com/tgjones/HlslTools/issues/18

I added export keyword and declaration allowance.

I also added a small test case (replicated inline version as it was the closest one to match the feature).

Thanks
Julien