### PR TITLE
Add explicit operator for Source Location

### DIFF
--- a/src/ShaderTools/Hlsl/Syntax/SourceLocation.cs
+++ b/src/ShaderTools/Hlsl/Syntax/SourceLocation.cs
@@ -69,5 +69,10 @@ namespace ShaderTools.Hlsl.Syntax
         {
             return Position.ToString();
         }
+
+        public static explicit operator int(SourceLocation c)
+        {
+            return c.Position;
+        }
     }
 }


### PR DESCRIPTION
Hello, just a little addition, so we can directly retreive position without some gymnastics (pointer or tostring)

As a side note, even if explicit is ok maybe we could use implicit? (which normally makes sense, as casting sourcelocation to int should never throw an exception.