### PR TITLE
Make intrinsic symbols public

### DIFF
--- a/src/ShaderTools/Hlsl/Symbols/IntrinsicAttributes.cs
+++ b/src/ShaderTools/Hlsl/Symbols/IntrinsicAttributes.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 
 namespace ShaderTools.Hlsl.Symbols
 {
-    internal static class IntrinsicAttributes
+    public static class IntrinsicAttributes
     {
         public static readonly ImmutableArray<AttributeSymbol> AllAttributes;
 

--- a/src/ShaderTools/Hlsl/Symbols/IntrinsicFunctions.cs
+++ b/src/ShaderTools/Hlsl/Symbols/IntrinsicFunctions.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace ShaderTools.Hlsl.Symbols
 {
-    internal static class IntrinsicFunctions
+    public static class IntrinsicFunctions
     {
         public static readonly IEnumerable<FunctionSymbol> AllFunctions;
 

--- a/src/ShaderTools/Hlsl/Symbols/IntrinsicNumericConstructors.cs
+++ b/src/ShaderTools/Hlsl/Symbols/IntrinsicNumericConstructors.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace ShaderTools.Hlsl.Symbols
 {
-    internal static class IntrinsicNumericConstructors
+    public static class IntrinsicNumericConstructors
     {
         public static readonly IEnumerable<FunctionSymbol> AllFunctions;
 

--- a/src/ShaderTools/Hlsl/Symbols/IntrinsicSemantics.cs
+++ b/src/ShaderTools/Hlsl/Symbols/IntrinsicSemantics.cs
@@ -3,7 +3,7 @@ using System.Collections.Immutable;
 
 namespace ShaderTools.Hlsl.Symbols
 {
-    internal static class IntrinsicSemantics
+    public static class IntrinsicSemantics
     {
         public static readonly ImmutableArray<SemanticSymbol> AllSemantics;
 

--- a/src/ShaderTools/Hlsl/Symbols/IntrinsicTypes.cs
+++ b/src/ShaderTools/Hlsl/Symbols/IntrinsicTypes.cs
@@ -6,7 +6,7 @@ using ShaderTools.Hlsl.Syntax;
 
 namespace ShaderTools.Hlsl.Symbols
 {
-    internal static class IntrinsicTypes
+    public static class IntrinsicTypes
     {
         public static readonly IntrinsicScalarTypeSymbol Void;
         public static readonly IntrinsicScalarTypeSymbol String;


### PR DESCRIPTION
Hello,

 another very small pull request, since Intrinsics symbols are immutable, it does not hurt to mark them as public (and allows to access them outside of visual studio extension)

Thanks