### PR TITLE
Add support for shaderlab in Unity

### DIFF
--- a/src/ShaderTools.VisualStudio.LanguageServices.Hlsl/HlslPackage.cs
+++ b/src/ShaderTools.VisualStudio.LanguageServices.Hlsl/HlslPackage.cs
@@ -37,6 +37,7 @@ namespace ShaderTools.VisualStudio.LanguageServices.Hlsl
     [ProvideLanguageExtension(typeof(HlslLanguageService), ".psh")]
     [ProvideLanguageExtension(typeof(HlslLanguageService), ".cginc")]
     [ProvideLanguageExtension(typeof(HlslLanguageService), ".compute")]
+    [ProvideLanguageExtension(typeof(HlslLanguageService), ".shader")]
 
     // Adds support for user mapping of custom file extensions.
     [ProvideFileExtensionMapping(


### PR DESCRIPTION
I don't know if this would work but i want HlslTools to support shaderlab in Unity
If this is in vain, please add extension ".shader" support, thanks!
