### PR TITLE
[Includes] Some improvements

### DIFF
--- a/src/ShaderTools.CodeAnalysis.Hlsl.EditorFeatures/OpenIncludeFile/OpenIncludeFileCommandHandler.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.EditorFeatures/OpenIncludeFile/OpenIncludeFileCommandHandler.cs
@@ -53,7 +53,7 @@ namespace ShaderTools.CodeAnalysis.Editor.Hlsl.OpenIncludeFile
 
             var currentFile = ((SyntaxTree) syntaxTree).File;
 
-            var include = includeFileResolver.OpenInclude(includeDirectiveTrivia.TrimmedFilename, currentFile);
+            var include = includeFileResolver.OpenInclude(includeDirectiveTrivia.TrimmedFilename, includeDirectiveTrivia.IsLocal ? IncludeType.Local : IncludeType.System, currentFile);
 
             if (include == null)
             {

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/CustomFileResolverTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/CustomFileResolverTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using ShaderTools.CodeAnalysis.Hlsl.Syntax;
+using ShaderTools.CodeAnalysis.Hlsl.Text;
+using ShaderTools.CodeAnalysis.Text;
+using Xunit;
+
+namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
+{
+    public class CustomFileResolverTests
+    {
+        private class MyCustomResolver : IIncludeFileResolver
+        {
+            public string Path { get; private set; }
+
+            public IncludeType IncludeType { get; private set; }
+
+            public bool HasBeenCalled { get; private set; }
+
+            public ImmutableArray<string> GetSearchDirectories(string includeFilename, SourceFile currentFile)
+            {
+                return new ImmutableArray<string>();
+            }
+
+            public SourceFile OpenInclude(string includeFilename, IncludeType includeType, SourceFile currentFile)
+            {
+                this.Path = includeFilename;
+                this.IncludeType = includeType;
+                this.HasBeenCalled = true;
+
+                return new SourceFile(SourceText.From(""), currentFile);
+            }
+
+        }
+
+
+        [Theory]
+        [InlineData("#include\"foo.fxh\"", IncludeType.Local, "foo.fxh")]
+        [InlineData("#include<foo.fxh>", IncludeType.System, "foo.fxh")]
+        public void TestName(string text, IncludeType includeType, string trimmedName)
+        {
+            MyCustomResolver resolver = new MyCustomResolver();
+
+            var expression = SyntaxFactory.ParseSyntaxTree(SourceText.From(text), null, null, resolver);
+
+            Assert.True(resolver.HasBeenCalled);
+            Assert.Equal(includeType, resolver.IncludeType);
+            Assert.Equal(trimmedName, resolver.Path);
+        }
+    }
+}

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/IncludeDirectiveTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/IncludeDirectiveTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using ShaderTools.CodeAnalysis.Hlsl.Syntax;
+using ShaderTools.CodeAnalysis.Text;
+using Xunit;
+
+namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
+{
+    public class IncludeDirectiveTests
+    {
+        [Theory]
+        [InlineData("#include\"foo.fxh\"", true, "foo.fxh")]
+        [InlineData("#include<foo.fxh>", false, "foo.fxh")]
+        public void TestName(string text, bool isLocal, string trimmedName)
+        {
+            var expression = SyntaxFactory.ParseSyntaxTree(SourceText.From(text));
+            var trivia = ((SyntaxToken)expression.Root.ChildNodes[0]).LeadingTrivia;
+
+            Assert.Equal(1, trivia.Length);
+                
+            var includeTrivia = (IncludeDirectiveTriviaSyntax)trivia[0];
+
+            Assert.NotNull(expression);
+            Assert.Equal(SyntaxKind.IncludeDirectiveTrivia, includeTrivia.Kind);
+
+            IncludeDirectiveTriviaSyntax directive = (IncludeDirectiveTriviaSyntax)includeTrivia;
+
+            Assert.Equal(isLocal, directive.IsLocal);
+            Assert.Equal(trimmedName, directive.TrimmedFilename);
+        }
+    }
+}

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Support/InMemoryFileSystem.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Support/InMemoryFileSystem.cs
@@ -13,7 +13,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Support
             _includes = includes;
         }
 
-        public bool TryGetFile(string path, out SourceText text)
+        public bool TryGetFile(string path, IncludeType includeType, out SourceText text)
         {
             string include;
             if (_includes.TryGetValue(path, out include))

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Support/TestFileSystem.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Support/TestFileSystem.cs
@@ -6,7 +6,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Support
 {
     public sealed class TestFileSystem : IIncludeFileSystem
     {
-        public bool TryGetFile(string path, out SourceText text)
+        public bool TryGetFile(string path, IncludeType includeType, out SourceText text)
         {
             if (File.Exists(path))
             {

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Workspaces/LanguageServices/HlslSyntaxTreeFactoryService.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Workspaces/LanguageServices/HlslSyntaxTreeFactoryService.cs
@@ -34,6 +34,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.LanguageServices
                 text,
                 options,
                 _fileSystem,
+                null,
                 cancellationToken);
         }
     }

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Workspaces/LanguageServices/WorkspaceFileSystem.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Workspaces/LanguageServices/WorkspaceFileSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using ShaderTools.CodeAnalysis;
+using ShaderTools.CodeAnalysis.Hlsl.Text;
 using ShaderTools.CodeAnalysis.Text;
 
 namespace ShaderTools.CodeAnalysis.Hlsl.LanguageServices
@@ -14,7 +15,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.LanguageServices
             _workspace = workspace;
         }
 
-        public bool TryGetFile(string path, out SourceText text)
+        public bool TryGetFile(string path, IncludeType includeType, out SourceText text)
         {
             // Is file open in workspace?
             var document = _workspace.CurrentDocuments

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.cs
@@ -58,11 +58,11 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
         // - {main.hlsl, 101, 200}
         internal List<FileSegment> FileSegments { get; }
 
-        public HlslLexer(SourceFile file, HlslParseOptions options = null, IIncludeFileSystem includeFileSystem = null)
+        public HlslLexer(SourceFile file, HlslParseOptions options = null, IIncludeFileSystem includeFileSystem = null, IIncludeFileResolver includeFileResolver = null)
         {
             _rootFile = file;
 
-            _includeFileResolver = new IncludeFileResolver(
+            _includeFileResolver = includeFileResolver ?? new IncludeFileResolver(
                 includeFileSystem ?? new DummyFileSystem(), 
                 options ?? new HlslParseOptions());
 

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.cs
@@ -300,7 +300,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
                 SourceFile include;
                 try
                 {
-                    include = _includeFileResolver.OpenInclude(includeFilename, _includeStack.Peek().File);
+                    include = _includeFileResolver.OpenInclude(includeFilename, includeDirective.IsLocal ? IncludeType.Local : IncludeType.System, _includeStack.Peek().File);
                     if (include == null)
                     {
                         includeDirective = includeDirective.WithDiagnostic(Diagnostic.Create(HlslMessageProvider.Instance, includeDirective.SourceRange, (int) DiagnosticId.IncludeNotFound, includeFilename));

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/DirectiveTriviaSyntax.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/DirectiveTriviaSyntax.cs
@@ -448,6 +448,8 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
 
         public string TrimmedFilename => Filename.Text.TrimStart('<', '"').TrimEnd('>', '"');
 
+        public bool IsLocal => !Filename.Text.StartsWith("<");
+
         public IncludeDirectiveTriviaSyntax(SyntaxToken hashToken, SyntaxToken includeKeyword, SyntaxToken filename, SyntaxToken endOfDirectiveToken, bool isActive, IEnumerable<Diagnostic> diagnostics)
             : base(SyntaxKind.IncludeDirectiveTrivia, diagnostics)
         {

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxFactory.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxFactory.cs
@@ -10,31 +10,31 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
 {
     public static class SyntaxFactory
     {
-        public static SyntaxTree ParseSyntaxTree(SourceText sourceText, HlslParseOptions options = null, IIncludeFileSystem fileSystem = null, CancellationToken cancellationToken = default(CancellationToken))
+        public static SyntaxTree ParseSyntaxTree(SourceText sourceText, HlslParseOptions options = null, IIncludeFileSystem fileSystem = null, IIncludeFileResolver fileResolver = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Parse(sourceText, options, fileSystem ?? new DummyFileSystem(), p => p.ParseCompilationUnit(cancellationToken));
+            return Parse(sourceText, options, fileSystem ?? new DummyFileSystem(), fileResolver, p => p.ParseCompilationUnit(cancellationToken));
         }
 
-        public static CompilationUnitSyntax ParseCompilationUnit(SourceText sourceText, IIncludeFileSystem fileSystem = null)
+        public static CompilationUnitSyntax ParseCompilationUnit(SourceText sourceText, IIncludeFileSystem fileSystem = null, IIncludeFileResolver fileResolver = null)
         {
-            return (CompilationUnitSyntax) Parse(sourceText, null, fileSystem, p => p.ParseCompilationUnit(CancellationToken.None)).Root;
+            return (CompilationUnitSyntax) Parse(sourceText, null, fileSystem, fileResolver, p => p.ParseCompilationUnit(CancellationToken.None)).Root;
         }
 
         public static SyntaxTree ParseExpression(string text)
         {
-            return Parse(SourceText.From(text), null, null, p => p.ParseExpression());
+            return Parse(SourceText.From(text), null, null, null, p => p.ParseExpression());
         }
 
         public static StatementSyntax ParseStatement(string text)
         {
-            return (StatementSyntax) Parse(SourceText.From(text), null, null, p => p.ParseStatement()).Root;
+            return (StatementSyntax) Parse(SourceText.From(text), null, null, null, p => p.ParseStatement()).Root;
         }
 
-        private static SyntaxTree Parse(SourceText sourceText, HlslParseOptions options, IIncludeFileSystem fileSystem, Func<HlslParser, SyntaxNode> parseFunc)
+        private static SyntaxTree Parse(SourceText sourceText, HlslParseOptions options, IIncludeFileSystem fileSystem, IIncludeFileResolver fileResolver, Func <HlslParser, SyntaxNode> parseFunc)
         {
             var sourceFile = new SourceFile(sourceText, null);
 
-            var lexer = new HlslLexer(sourceFile, options, fileSystem);
+            var lexer = new HlslLexer(sourceFile, options, fileSystem, fileResolver);
             var parser = new HlslParser(lexer);
 
             var result = new SyntaxTree(

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Text/DummyFileSystem.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Text/DummyFileSystem.cs
@@ -4,7 +4,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Text
 {
     internal sealed class DummyFileSystem : IIncludeFileSystem
     {
-        public bool TryGetFile(string path, out SourceText text)
+        public bool TryGetFile(string path, IncludeType includeType, out SourceText text)
         {
             text = null;
             return false;

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Text/IIncludeFileResolver.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Text/IIncludeFileResolver.cs
@@ -6,6 +6,6 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Text
     public interface IIncludeFileResolver
     {
         ImmutableArray<string> GetSearchDirectories(string includeFilename, SourceFile currentFile);
-        SourceFile OpenInclude(string includeFilename, SourceFile currentFile);
+        SourceFile OpenInclude(string includeFilename, IncludeType includeType, SourceFile currentFile);
     }
 }

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Text/IIncludeFileSystem.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Text/IIncludeFileSystem.cs
@@ -4,6 +4,6 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Text
 {
     public interface IIncludeFileSystem
     {
-        bool TryGetFile(string path, out SourceText text);
+        bool TryGetFile(string path, IncludeType includeType, out SourceText text);
     }
 }

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Text/IncludeFileResolver.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Text/IncludeFileResolver.cs
@@ -41,7 +41,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Text
             return result.ToImmutable();
         }
 
-        public SourceFile OpenInclude(string includeFilename, SourceFile currentFile)
+        public SourceFile OpenInclude(string includeFilename, IncludeType includeType, SourceFile currentFile)
         {
             SourceText text;
 
@@ -56,7 +56,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Text
             // If path is rooted, open it directly.
             if (Path.IsPathRooted(includeFilename))
             {
-                if (_fileSystem.TryGetFile(includeFilename, out text))
+                if (_fileSystem.TryGetFile(includeFilename, includeType, out text))
                     return new SourceFile(text, currentFile);
                 return null;
             }
@@ -70,7 +70,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Text
                 {
                     var rootFileDirectory = Path.GetDirectoryName(fileToCheck.FilePath);
                     var testFilename = Path.Combine(rootFileDirectory, includeFilename);
-                    if (_fileSystem.TryGetFile(testFilename, out text))
+                    if (_fileSystem.TryGetFile(testFilename, includeType, out text))
                         return new SourceFile(text, currentFile);
                 }
                 fileToCheck = fileToCheck.IncludedBy;
@@ -80,7 +80,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Text
             foreach (var includeDirectory in _parserOptions.AdditionalIncludeDirectories)
             {
                 var testFilename = Path.Combine(includeDirectory, includeFilename);
-                if (_fileSystem.TryGetFile(testFilename, out text))
+                if (_fileSystem.TryGetFile(testFilename, includeType, out text))
                     return new SourceFile(text, currentFile);
             }
 

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Text/IncludeType.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Text/IncludeType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShaderTools.CodeAnalysis.Hlsl.Text
+{
+    /// <summary>
+    /// Defines hlsl include type
+    /// </summary>
+    public enum IncludeType
+    {
+        /// <summary>
+        /// Local include (we should look in folder relative to the code file)
+        /// </summary>
+        Local,
+        /// <summary>
+        /// System include generally defined by executable path, or application specified folders
+        /// </summary>
+        System
+    }
+}

--- a/src/ShaderTools.CodeAnalysis/Text/SourceFile.cs
+++ b/src/ShaderTools.CodeAnalysis/Text/SourceFile.cs
@@ -16,7 +16,7 @@ namespace ShaderTools.CodeAnalysis.Text
 
         public bool IsRootFile => IncludedBy == null;
 
-        internal SourceFile(SourceText text, SourceFile includedBy)
+        public SourceFile(SourceText text, SourceFile includedBy)
         {
             Text = text ?? throw new ArgumentNullException(nameof(text));
             IncludedBy = includedBy;


### PR DESCRIPTION
Hello, as mentioned in #130 , here are some improvements for include system :  

The main rationale about it is to also allow some finer control when using core libraries in custom tooling.

- Added Include type enumeration
- IncludeDirectiveTriviaSyntax gets a boolean "IsLocal"
- Pass Include type to both Include Resolver and File System (depending on local flag)
- Current file systems and resolver are ignoring flag (so this will not be a breaking change)
- Allow to pass our own IIncludeFileResolver to ParseSyntaxTree .
- To be allowed to use our own IIncludeFileResolver, we need to provide a source file, so constructor is now public.

- I added small tests to verify that syntax flags are correct, and that custom resolver gets called properly.

One discussion part I would have, is that passing IIncludeFileResolver is required, since our include system might not be not file based (zip/resource/memory...) so default resolver will never find the file, and never call the filesystem.

So maybe we should even remove IIncludeFileSystem from the argument list (since resolver should provide it's own file system anyway, or never provide one) ?

Thanks