### PR TITLE
Improve tabs/spaces handling in smart indent / autoformat

### DIFF
--- a/src/ShaderTools.CodeAnalysis.EditorFeatures/Implementation/SmartIndent/SmartIndent.cs
+++ b/src/ShaderTools.CodeAnalysis.EditorFeatures/Implementation/SmartIndent/SmartIndent.cs
@@ -48,14 +48,14 @@ namespace ShaderTools.CodeAnalysis.Editor.Implementation.SmartIndent
                     return DoBlockIndent(line, documentOptions);
 
                 case FormattingOptions.IndentStyle.Smart:
-                    return DoSmartIndent(line, document, cancellationToken);
+                    return DoSmartIndent(line, document, documentOptions, cancellationToken);
 
                 default:
                     return null;
             }
         }
 
-        private int? DoSmartIndent(ITextSnapshotLine line, Document document, CancellationToken cancellationToken)
+        private int? DoSmartIndent(ITextSnapshotLine line, Document document, DocumentOptionSet optionSet, CancellationToken cancellationToken)
         {
             var indentationService = document.GetLanguageService<IIndentationService>();
             var syntaxFactsService = document.GetLanguageService<ISyntaxFactsService>();
@@ -65,7 +65,8 @@ namespace ShaderTools.CodeAnalysis.Editor.Implementation.SmartIndent
             var indent = FindTotalParentChainIndent(
                 syntaxTree.Root,
                 line.Start.Position, 
-                0, 
+                0,
+                optionSet.GetOption(FormattingOptions.IndentationSize),
                 indentationService,
                 syntaxFactsService);
 
@@ -77,6 +78,7 @@ namespace ShaderTools.CodeAnalysis.Editor.Implementation.SmartIndent
             SyntaxNodeBase node, 
             int position, 
             int indent, 
+            int indentSize,
             IIndentationService indentationService,
             ISyntaxFactsService syntaxFactsService)
         {
@@ -100,13 +102,13 @@ namespace ShaderTools.CodeAnalysis.Editor.Implementation.SmartIndent
 
                 var shouldIndent = indentationService.ShouldIndent(child);
                 if (shouldIndent)
-                    indent += 4;
+                    indent += indentSize;
 
                 if (position <= childSpan.Value.Span.End)
-                    return FindTotalParentChainIndent(child, position, indent, indentationService, syntaxFactsService);
+                    return FindTotalParentChainIndent(child, position, indent, indentSize, indentationService, syntaxFactsService);
 
                 if (shouldIndent)
-                    indent -= 4;
+                    indent -= indentSize;
             }
 
             return indent;

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Workspaces/Options/HlslOptionsService.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Workspaces/Options/HlslOptionsService.cs
@@ -62,6 +62,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Options
                     InsertSpaceWithinEmptySquareBrackets = options.GetOption(HlslFormattingOptions.SpaceWithinEmptySquareBrackets)
                 },
 
+                UseTabs = options.GetOption(CodeAnalysis.Formatting.FormattingOptions.UseTabs, LanguageNames.Hlsl),
                 SpacesPerIndent = options.GetOption(CodeAnalysis.Formatting.FormattingOptions.IndentationSize, LanguageNames.Hlsl)
             };
         }

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Formatting/FormattingOptions.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Formatting/FormattingOptions.cs
@@ -66,7 +66,8 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Formatting
         public NewLinesOptions NewLines { get; set; }
         public SpacingOptions Spacing { get; set; }
 
-        public int? SpacesPerIndent { get; set; }
+        public bool UseTabs { get; set; }
+        public int SpacesPerIndent { get; set; }
         public string NewLine { get; set; }
 
         public FormattingOptions()
@@ -75,6 +76,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Formatting
             NewLines = new NewLinesOptions();
             Spacing = new SpacingOptions();
 
+            UseTabs = false;
             SpacesPerIndent = 4;
             NewLine = Environment.NewLine;
         }

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Formatting/FormattingVisitor.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Formatting/FormattingVisitor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -1728,12 +1728,16 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Formatting
                 _whitespace.Add(null);
             }
 
-            if (_options.SpacesPerIndent != null)
+            if (_options.UseTabs)
+            {
+                return _whitespace[_indentLevel] = new string('\t', _indentLevel);
+            }
+            else 
+            {
                 return _whitespace[_indentLevel] = new string(
                     ' ',
-                    _indentLevel * _options.SpacesPerIndent.Value);
-
-            return _whitespace[_indentLevel] = new string('\t', _indentLevel);
+                    _indentLevel * _options.SpacesPerIndent);
+            }
         }
 
         private void Indent()

--- a/src/ShaderTools.Editor.VisualStudio.Tests/Hlsl/Editing/SmartIndenting/SmartIndentTests.cs
+++ b/src/ShaderTools.Editor.VisualStudio.Tests/Hlsl/Editing/SmartIndenting/SmartIndentTests.cs
@@ -2,6 +2,7 @@
 using ShaderTools.CodeAnalysis.Editor.Hlsl.SmartIndent;
 using ShaderTools.CodeAnalysis.Editor.Implementation.SmartIndent;
 using ShaderTools.CodeAnalysis.Hlsl.Syntax;
+using ShaderTools.CodeAnalysis.Options;
 using ShaderTools.CodeAnalysis.Text;
 using Xunit;
 
@@ -65,7 +66,7 @@ namespace ShaderTools.Editor.VisualStudio.Tests.Hlsl.Editing.SmartIndenting
 
             var code = codeWithCaret.Remove(caret, 1);
             var syntaxTree = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(code)));
-            var actualIndent = SmartIndent.FindTotalParentChainIndent((SyntaxNode) syntaxTree.Root, caret, 0, indentationService, syntaxFactsService);
+            var actualIndent = SmartIndent.FindTotalParentChainIndent((SyntaxNode) syntaxTree.Root, caret, 0, 4, indentationService, syntaxFactsService);
             Assert.Equal(expectedIndent, actualIndent);
         }
     }


### PR DESCRIPTION
* Smart indent uses document indent size setting instead of hard-coded 4
* Autoformat respects document tabs/spaces setting

Addresses issue #103. However, there's still some weirdness with a blank line getting added when typing `)`.