### PR TITLE
Fix crash in Navigate To when symbol name is null

### DIFF
--- a/src/ShaderTools.CodeAnalysis.Features/NavigateTo/NavigateToSearchService.cs
+++ b/src/ShaderTools.CodeAnalysis.Features/NavigateTo/NavigateToSearchService.cs
@@ -38,6 +38,7 @@ namespace ShaderTools.CodeAnalysis.NavigateTo
                 if (declaredSymbol != null 
                     && declaredSymbol.Kind != SymbolKind.Parameter
                     && (declaredSymbol.Kind != SymbolKind.Variable || declaredSymbol.Parent == null || declaredSymbol.Parent.Kind != SymbolKind.Function)
+                    && declaredSymbol.Name != null
                     && Contains(declaredSymbol.Name, searchPattern))
                 {
                     var matchKind = declaredSymbol.Name.StartsWith(searchPattern, StringComparison.CurrentCultureIgnoreCase)


### PR DESCRIPTION
Guard against Name being null. This happened in our codebase due to unnamed techniques (which are legal in HLSL).