### PR TITLE
Support relative path in virtual directory mapping

### DIFF
--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
@@ -974,7 +974,7 @@ float bar;
                 {
                     VirtualDirectoryMappings =
                     {
-                        { "C:\\Project", "C:\\test" }
+                        { "\\Project", "C:\\test" }
                     }
                 },
                 new InMemoryFileSystem(new Dictionary<string, string>

--- a/src/ShaderTools.CodeAnalysis.Tests/Options/Assets/ChildFolder/GrandchildFolder/shadertoolsconfig.json
+++ b/src/ShaderTools.CodeAnalysis.Tests/Options/Assets/ChildFolder/GrandchildFolder/shadertoolsconfig.json
@@ -6,5 +6,14 @@
   "hlsl.additionalIncludeDirectories": [
     "../Bar",
     "..\\Foo"
-  ]
+  ],
+
+  "hlsl.virtualDirectoryMappings": {
+    "../Bar": "D:/read_full",
+    "..\\Foo": "File",
+    "C:/FULL": "\\Root",
+    "hello": "../PARENT",
+    "/world": ".\\THIS",
+    "D:\\One/Drive": "C:/Another\\Drive"
+  }
 }

--- a/src/ShaderTools.CodeAnalysis.Tests/Options/ConfigFileTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Tests/Options/ConfigFileTests.cs
@@ -32,6 +32,7 @@ namespace ShaderTools.CodeAnalysis.Tests.Options
                 configFile.HlslAdditionalIncludeDirectories);
 
             var root = Path.GetPathRoot(workingDirectory);
+            var pathSeparator = Path.DirectorySeparatorChar.ToString();
             Assert.Equal(
                 new Dictionary<string, string>
                 {
@@ -40,6 +41,7 @@ namespace ShaderTools.CodeAnalysis.Tests.Options
                     { Path.GetFullPath("C:/FULL"), Path.Combine(root, "Root") },
                     { Path.Combine(workingDirectory, "ChildFolder", "GrandchildFolder", "hello"), Path.Combine(workingDirectory, "ChildFolder", "PARENT") },
                     { Path.Combine(root, "world"), Path.Combine(workingDirectory, "ChildFolder", "GrandchildFolder", "THIS") },
+                    { Path.Combine(pathSeparator, "world"), Path.Combine(workingDirectory, "ChildFolder", "GrandchildFolder", "THIS") },
                     { Path.GetFullPath("D:/One/Drive"), Path.GetFullPath("C:/Another/Drive") },
                 },
                 configFile.HlslVirtualDirectoryMappings);

--- a/src/ShaderTools.CodeAnalysis.Tests/Options/ConfigFileTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Tests/Options/ConfigFileTests.cs
@@ -30,6 +30,19 @@ namespace ShaderTools.CodeAnalysis.Tests.Options
                     workingDirectory
                 },
                 configFile.HlslAdditionalIncludeDirectories);
+
+            var root = Path.GetPathRoot(workingDirectory);
+            Assert.Equal(
+                new Dictionary<string, string>
+                {
+                    { Path.Combine(workingDirectory, "ChildFolder", "Bar"), Path.GetFullPath("D:/read_full") },
+                    { Path.Combine(workingDirectory, "ChildFolder", "Foo"), Path.Combine(workingDirectory, "ChildFolder", "GrandchildFolder", "File") },
+                    { Path.GetFullPath("C:/FULL"), Path.Combine(root, "Root") },
+                    { Path.Combine(workingDirectory, "ChildFolder", "GrandchildFolder", "hello"), Path.Combine(workingDirectory, "ChildFolder", "PARENT") },
+                    { Path.Combine(root, "world"), Path.Combine(workingDirectory, "ChildFolder", "GrandchildFolder", "THIS") },
+                    { Path.GetFullPath("D:/One/Drive"), Path.GetFullPath("C:/Another/Drive") },
+                },
+                configFile.HlslVirtualDirectoryMappings);
         }
 
         [Fact]

--- a/src/ShaderTools.CodeAnalysis/Options/ConfigFileLoader.cs
+++ b/src/ShaderTools.CodeAnalysis/Options/ConfigFileLoader.cs
@@ -37,9 +37,13 @@ namespace ShaderTools.CodeAnalysis.Options
                 var configFileDir = Path.GetDirectoryName(configFile.FileName);
                 foreach (var virtualDirectoryMapping in configFile.HlslVirtualDirectoryMappings)
                 {
-                    var key = CalculateFullPath(configFileDir, virtualDirectoryMapping.Key);
+                    var originalKey = virtualDirectoryMapping.Key;
+                    var key = CalculateFullPath(configFileDir, originalKey);
                     var value = CalculateFullPath(configFileDir, virtualDirectoryMapping.Value);
                     hlslVirtualDirectoryMappings[key] = value;
+                    // If originalKey is a rooted path without drive letter, add normalized rooted path without drive letter
+                    if (Path.IsPathRooted(originalKey) && Path.GetPathRoot(originalKey).Length == 1)
+                        hlslVirtualDirectoryMappings[RemoveDriveLetter(key)] = value;
                 }
             }
 
@@ -54,6 +58,11 @@ namespace ShaderTools.CodeAnalysis.Options
 
                 HlslVirtualDirectoryMappings = hlslVirtualDirectoryMappings,
             };
+        }
+
+        private static string RemoveDriveLetter(string path)
+        {
+            return Path.DirectorySeparatorChar + path.Substring(Path.GetPathRoot(path).Length);
         }
 
         private static string CalculateFullPath(string basePath, string path)

--- a/src/ShaderTools.CodeAnalysis/Options/ConfigFileLoader.cs
+++ b/src/ShaderTools.CodeAnalysis/Options/ConfigFileLoader.cs
@@ -33,10 +33,15 @@ namespace ShaderTools.CodeAnalysis.Options
 
             var hlslVirtualDirectoryMappings = new Dictionary<string, string>();
             foreach (var configFile in configFiles.Reverse())
+            {
+                var configFileDir = Path.GetDirectoryName(configFile.FileName);
                 foreach (var virtualDirectoryMapping in configFile.HlslVirtualDirectoryMappings)
-                    hlslVirtualDirectoryMappings[virtualDirectoryMapping.Key] = virtualDirectoryMapping.Value
-                        .Replace('/', Path.DirectorySeparatorChar)
-                        .Replace('\\', Path.DirectorySeparatorChar);
+                {
+                    var key = CalculateFullPath(configFileDir, virtualDirectoryMapping.Key);
+                    var value = CalculateFullPath(configFileDir, virtualDirectoryMapping.Value);
+                    hlslVirtualDirectoryMappings[key] = value;
+                }
+            }
 
             return new ConfigFile
             {
@@ -49,6 +54,23 @@ namespace ShaderTools.CodeAnalysis.Options
 
                 HlslVirtualDirectoryMappings = hlslVirtualDirectoryMappings,
             };
+        }
+
+        private static string CalculateFullPath(string basePath, string path)
+        {
+            var result = path
+                .Replace('/', Path.DirectorySeparatorChar)
+                .Replace('\\', Path.DirectorySeparatorChar);
+            if (!Path.IsPathRooted(result))
+            {
+                result = Path.GetFullPath(Path.Combine(basePath, result));
+            }
+            else
+            {
+                // Even if result is a rooted path, we still need to add drive letter and normalize the path
+                result = Path.GetFullPath(result);
+            }
+            return result;
         }
 
         private static IEnumerable<ConfigFile> GetConfigFiles(string initialDirectory)


### PR DESCRIPTION
Supported use of relative path in virtual directory key, value and include path.

For example, we write shadertoolsconfig.json like this:
```json
{
    "hlsl.additionalIncludeDirectories": [
        ".",
        "/UnityProjects\\PlaygroundHDRP"
    ],
    "hlsl.virtualDirectoryMappings": {
        "Packages\\com.unity.render-pipelines.high-definition": "D:\\UnityProjects\\PlaygroundHDRP\\Library\\PackageCache\\com.unity.render-pipelines.high-definition@12.1.6", 
        "D:\\UnityProjects/PlaygroundHDRP\\Packages\\com.unity.render-pipelines.core": "Library/PackageCache\\com.unity.render-pipelines.core@12.1.6"
    }
}
```

Then HlslTools extension can correctly parse the include paths like these:
```hlsl
#include "/UnityProjects/PlaygroundHDRP\\Packages\\com.unity.render-pipelines.core/ShaderLibrary/Sampling/SampleUVMapping.hlsl"
#include "/UnityProjects\\PlaygroundHDRP\\Library\\PackageCache\\com.unity.render-pipelines.high-definition@12.1.6/Runtime/Material/MaterialUtilities.hlsl"
#include "D:\\UnityProjects/PlaygroundHDRP\\Packages\\com.unity.render-pipelines.core/ShaderLibrary/Sampling/SampleUVMapping.hlsl"
#include "D:\\UnityProjects\\PlaygroundHDRP\\Library\\PackageCache\\com.unity.render-pipelines.high-definition@12.1.6/Runtime/Material/MaterialUtilities.hlsl"
#include "Packages/com.unity.render-pipelines.core\\ShaderLibrary/Sampling\\SampleUVMapping.hlsl"
#include "Packages\\com.unity.render-pipelines.high-definition/Runtime/Material/MaterialUtilities.hlsl"
```

The logic is like this: In the json file we have `"<vpath>": "<rpath>"` pairs. The extension will create a virtual directory at `<vpath>`, which will be mapped to the real path `<rpath>`. If `<vpath>` or `<rpath>` is not a fully qualified path, then absolute fully qualified path will be calculated based on the path of json file. And when the extension searches include files, it will obey the normal search rule. If the include path is a relative path, tries to prefix include directories and convert it to absolute path. And then tries to find the file in that path, considering virtual directories.