### PR TITLE
Deactivate VSCode extension asynchronously

### DIFF
--- a/src/ShaderTools.VSCode/src/main.ts
+++ b/src/ShaderTools.VSCode/src/main.ts
@@ -9,3 +9,7 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(sessionManager = new SessionManager());
     sessionManager.start();
 }
+
+export function deactivate(): Promise<void> {
+    return sessionManager.stop();
+}

--- a/src/ShaderTools.VSCode/src/session.ts
+++ b/src/ShaderTools.VSCode/src/session.ts
@@ -35,7 +35,7 @@ export class SessionManager {
         this.startEditorServices();
     }
 
-    public stop() {
+    public stop(): Promise<void> {
         if (this.sessionStatus === SessionStatus.Failed) {
             // Before moving further, clear out the client and process if
             // the process is already dead (i.e. it crashed)
@@ -44,13 +44,17 @@ export class SessionManager {
 
         this.sessionStatus = SessionStatus.Stopping;
 
+        var promise = Promise.resolve();
+
         // Close the language server client
         if (this.languageServerClient !== undefined) {
-            this.languageServerClient.stop();
+            promise = this.languageServerClient.stop();
             this.languageServerClient = undefined;
         }
 
         this.sessionStatus = SessionStatus.NotStarted;
+        
+        return promise;
     }
 
     public dispose() : void {


### PR DESCRIPTION
### Description

When using HLSL Tools on MacOS, orphaned ShaderTools.LanguageServer processes will accumulate, wasting memory. This happens after closing and opening VSCode repeatedly. This does not appear to happen on Windows in my experience.

https://github.com/microsoft/vscode/issues/35196#issuecomment-334399348

The above GitHub issue details other developers' experiences with the same problem. The solution presented by dbaeumer was to return a `Promise` from an exported `deactivate()`.

https://code.visualstudio.com/api/references/activation-events#Start-up

This is confirmed by the above VSCode docs. Extensions with asynchronous cleanup processes must return a `Promise` from their `deactivate()`. As `LanguageServerClient.stop()` returns a `Promise`, we are obligated to return it when deactivating.

### Testing

Tested by copying compilation results from `main.ts` and `session.ts` into the existing `.vscode/extensions` extension folder.

* Verified that "Restart Current Session" works as it did previously on MacOS and Windows.
* Verified that ShaderTools.LanguageServer processes were stopped after closing VSCode windows and quitting VSCode on MacOS and Windows (even though Windows didn't have this issue).