### PR TITLE
Fix Assert warnings in Unit Test projects

### DIFF
--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Binding/GlobalDeclarationTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Binding/GlobalDeclarationTests.cs
@@ -20,7 +20,7 @@ int foo;";
             var semanticModel = compilation.GetSemanticModel();
             var diagnostics = syntaxTree.GetDiagnostics().Concat(semanticModel.GetDiagnostics()).ToImmutableArray();
 
-            Assert.Equal(1, diagnostics.Length);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticId.SymbolRedefined, (DiagnosticId) diagnostics[0].Descriptor.Code);
         }
 
@@ -35,7 +35,7 @@ void foo();";
             var semanticModel = compilation.GetSemanticModel();
             var diagnostics = syntaxTree.GetDiagnostics().Concat(semanticModel.GetDiagnostics()).ToImmutableArray();
 
-            Assert.Equal(1, diagnostics.Length);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticId.SymbolRedefined, (DiagnosticId) diagnostics[0].Descriptor.Code);
         }
 
@@ -52,7 +52,7 @@ void main()
             var semanticModel = compilation.GetSemanticModel();
             var diagnostics = syntaxTree.GetDiagnostics().Concat(semanticModel.GetDiagnostics()).ToImmutableArray();
 
-            Assert.Equal(1, diagnostics.Length);
+            Assert.Single(diagnostics);
             Assert.Equal(DiagnosticId.UndeclaredVariable, (DiagnosticId) diagnostics[0].Descriptor.Code);
         }
     }

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/DeclarationParsingTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/DeclarationParsingTests.cs
@@ -396,15 +396,15 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
-            Assert.Equal(0, file.GetDiagnostics().Count());
+            Assert.Empty(file.GetDiagnostics());
 
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, file.Declarations[0].Kind);
             var fs = (VariableDeclarationStatementSyntax)file.Declarations[0];
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal(typeText, fs.Declaration.Type.ToString());
-            Assert.Equal(1, fs.Declaration.Variables.Count);
+            Assert.Single(fs.Declaration.Variables);
             Assert.NotNull(fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].Initializer);
@@ -420,16 +420,16 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
-            Assert.Equal(0, file.GetDiagnostics().Count());
+            Assert.Empty(file.GetDiagnostics());
 
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, file.Declarations[0].Kind);
             var fs = (VariableDeclarationStatementSyntax)file.Declarations[0];
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal(typeText, fs.Declaration.Type.ToString());
             Assert.Equal(SyntaxKind.PredefinedObjectType, fs.Declaration.Type.Kind);
-            Assert.Equal(1, fs.Declaration.Variables.Count);
+            Assert.Single(fs.Declaration.Variables);
             Assert.NotNull(fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].Initializer);
@@ -445,16 +445,16 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
-            Assert.Equal(0, file.GetDiagnostics().Count());
+            Assert.Empty(file.GetDiagnostics());
 
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, file.Declarations[0].Kind);
             var fs = (VariableDeclarationStatementSyntax)file.Declarations[0];
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal(typeText, fs.Declaration.Type.ToString());
             Assert.Equal(SyntaxKind.StructType, fs.Declaration.Type.Kind);
-            Assert.Equal(1, fs.Declaration.Variables.Count);
+            Assert.Single(fs.Declaration.Variables);
             Assert.NotNull(fs.Declaration.Variables[0].Identifier);
             Assert.Equal("c", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(fs.Declaration.Variables[0].Initializer);
@@ -471,16 +471,16 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
-            Assert.Equal(0, file.GetDiagnostics().Count());
+            Assert.Empty(file.GetDiagnostics());
 
             Assert.Equal(SyntaxKind.TypedefStatement, file.Declarations[0].Kind);
             var ts = (TypedefStatementSyntax)file.Declarations[0];
             Assert.NotNull(ts.Type);
             Assert.Equal(typeText, ts.Type.ToString());
             Assert.Equal(SyntaxKind.StructType, ts.Type.Kind);
-            Assert.Equal(1, ts.Declarators.Count);
+            Assert.Single(ts.Declarators);
             var ds = ts.Declarators[0];
             Assert.NotNull(ds.Identifier);
             Assert.Equal("c", ds.Identifier.ToString());
@@ -495,9 +495,9 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
-            Assert.Equal(0, file.GetDiagnostics().Count());
+            Assert.Empty(file.GetDiagnostics());
 
             Assert.Equal(SyntaxKind.FunctionDeclaration, file.Declarations[0].Kind);
             var fs = (FunctionDeclarationSyntax)file.Declarations[0];
@@ -506,7 +506,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal("Foo", fs.Name.ToString());
             Assert.NotNull(fs.ParameterList.OpenParenToken);
             Assert.False(fs.ParameterList.OpenParenToken.IsMissing);
-            Assert.Equal(1, fs.ParameterList.Parameters.Count);
+            Assert.Single(fs.ParameterList.Parameters);
             var fp = fs.ParameterList.Parameters[0];
             Assert.Equal("int", fp.Type.ToString());
             Assert.Equal("a", fp.Declarator.Identifier.ToString());
@@ -523,20 +523,20 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
-            Assert.Equal(0, file.GetDiagnostics().Count());
+            Assert.Empty(file.GetDiagnostics());
 
             Assert.Equal(SyntaxKind.FunctionDefinition, file.Declarations[0].Kind);
             var fs = (FunctionDefinitionSyntax)file.Declarations[0];
-            Assert.Equal(1, fs.Modifiers.Count);
+            Assert.Single(fs.Modifiers);
             Assert.Equal(SyntaxKind.InlineKeyword, fs.Modifiers[0].Kind);
             Assert.NotNull(fs.ReturnType);
             Assert.Equal("void", fs.ReturnType.ToString());
             Assert.Equal("Foo", fs.Name.ToString());
             Assert.NotNull(fs.ParameterList.OpenParenToken);
             Assert.False(fs.ParameterList.OpenParenToken.IsMissing);
-            Assert.Equal(1, fs.ParameterList.Parameters.Count);
+            Assert.Single(fs.ParameterList.Parameters);
             var fp = fs.ParameterList.Parameters[0];
             Assert.Equal("int", fp.Type.ToString());
             Assert.Equal("a", fp.Declarator.Identifier.ToString());
@@ -544,7 +544,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.False(fs.ParameterList.CloseParenToken.IsMissing);
             Assert.NotNull(fs.Body);
             Assert.NotNull(fs.Body.OpenBraceToken);
-            Assert.Equal(1, fs.Body.Statements.Count);
+            Assert.Single(fs.Body.Statements);
             Assert.NotNull(fs.Body.CloseBraceToken);
             Assert.Null(fs.SemicolonToken);
         }
@@ -556,20 +556,20 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
-            Assert.Equal(0, file.GetDiagnostics().Count());
+            Assert.Empty(file.GetDiagnostics());
 
             Assert.Equal(SyntaxKind.FunctionDefinition, file.Declarations[0].Kind);
             var fs = (FunctionDefinitionSyntax)file.Declarations[0];
-            Assert.Equal(1, fs.Modifiers.Count);
+            Assert.Single(fs.Modifiers);
             Assert.Equal(SyntaxKind.ExportKeyword, fs.Modifiers[0].Kind);
             Assert.NotNull(fs.ReturnType);
             Assert.Equal("void", fs.ReturnType.ToString());
             Assert.Equal("Foo", fs.Name.ToString());
             Assert.NotNull(fs.ParameterList.OpenParenToken);
             Assert.False(fs.ParameterList.OpenParenToken.IsMissing);
-            Assert.Equal(1, fs.ParameterList.Parameters.Count);
+            Assert.Single(fs.ParameterList.Parameters);
             var fp = fs.ParameterList.Parameters[0];
             Assert.Equal("int", fp.Type.ToString());
             Assert.Equal("a", fp.Declarator.Identifier.ToString());
@@ -577,7 +577,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.False(fs.ParameterList.CloseParenToken.IsMissing);
             Assert.NotNull(fs.Body);
             Assert.NotNull(fs.Body.OpenBraceToken);
-            Assert.Equal(1, fs.Body.Statements.Count);
+            Assert.Single(fs.Body.Statements);
             Assert.NotNull(fs.Body.CloseBraceToken);
             Assert.Null(fs.SemicolonToken);
         }
@@ -589,7 +589,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
             Assert.Empty(file.GetDiagnostics());
 
@@ -597,7 +597,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var fs = (VariableDeclarationStatementSyntax)file.Declarations[0];
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("SamplerState", fs.Declaration.Type.ToString());
-            Assert.Equal(1, fs.Declaration.Variables.Count);
+            Assert.Single(fs.Declaration.Variables);
             Assert.Equal("MySamplerState", fs.Declaration.Variables[0].Identifier.Text);
             Assert.Equal(SyntaxKind.StateInitializer, fs.Declaration.Variables[0].Initializer.Kind);
             var init = (StateInitializerSyntax) fs.Declaration.Variables[0].Initializer;
@@ -634,17 +634,17 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var file = ParseFile(text);
 
             Assert.NotNull(file);
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
             Assert.Equal(text, file.ToString());
-            Assert.Equal(1, file.GetDiagnostics().Count());
+            Assert.Single(file.GetDiagnostics());
 
             Assert.Equal(SyntaxKind.TechniqueDeclaration, file.Declarations[0].Kind);
             var fs = (TechniqueSyntax)file.Declarations[0];
             Assert.False(fs.TechniqueKeyword.IsMissing);
             Assert.Null(fs.Name);
-            Assert.Equal(1, fs.Passes.Count);
+            Assert.Single(fs.Passes);
             Assert.Equal("Pass1", fs.Passes[0].Name.Text);
-            Assert.Equal(0, fs.Passes[0].Statements.Count);
+            Assert.Empty(fs.Passes[0].Statements);
 
             Assert.NotNull(fs.SemicolonToken);
         }
@@ -658,11 +658,11 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(file);
             Assert.Empty(file.GetDiagnostics());
             Assert.Equal(text, file.ToString());
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
 
             Assert.Equal(SyntaxKind.FunctionDefinition, file.Declarations[0].Kind);
             var fd = (FunctionDefinitionSyntax)file.Declarations[0];
-            Assert.Equal(1, fd.Attributes.Count);
+            Assert.Single(fd.Attributes);
         }
 
         [Fact]
@@ -674,11 +674,11 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(file);
             Assert.Empty(file.GetDiagnostics());
             Assert.Equal(text, file.ToString());
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
 
             Assert.Equal(SyntaxKind.FunctionDefinition, file.Declarations[0].Kind);
             var fd = (FunctionDefinitionSyntax)file.Declarations[0];
-            Assert.Equal(1, fd.ParameterList.Parameters[0].Attributes.Count);
+            Assert.Single(fd.ParameterList.Parameters[0].Attributes);
         }
 
         [Fact]
@@ -690,11 +690,11 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(file);
             Assert.Empty(file.GetDiagnostics());
             Assert.Equal(text, file.ToString());
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
 
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, file.Declarations[0].Kind);
             var fd = (VariableDeclarationStatementSyntax)file.Declarations[0];
-            Assert.Equal(1, fd.Attributes.Count);
+            Assert.Single(fd.Attributes);
         }
 
         [Fact]
@@ -706,7 +706,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(file);
             Assert.Empty(file.GetDiagnostics());
             Assert.Equal(text, file.ToString());
-            Assert.Equal(1, file.Declarations.Count);
+            Assert.Single(file.Declarations);
 
             Assert.Equal(SyntaxKind.TypeDeclarationStatement, file.Declarations[0].Kind);
             var fd = (TypeDeclarationStatementSyntax)file.Declarations[0];
@@ -714,7 +714,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var st = (StructTypeSyntax)fd.Type;
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, st.Members[0].Kind);
             var vd = (VariableDeclarationStatementSyntax)st.Members[0];
-            Assert.Equal(1, vd.Attributes.Count);
+            Assert.Single(vd.Attributes);
         }
 
         [Fact]
@@ -730,7 +730,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, file.Declarations[1].Kind);
             var fd = (VariableDeclarationStatementSyntax)file.Declarations[1];
-            Assert.Equal(1, fd.Attributes.Count);
+            Assert.Single(fd.Attributes);
         }
 
         private static CompilationUnitSyntax ParseFile(string text)

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/ErrorRecoveryTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/ErrorRecoveryTests.cs
@@ -46,7 +46,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.False(structDefinitionSyntax.StructKeyword.IsMissing);
             Assert.False(structDefinitionSyntax.Name.IsMissing);
             Assert.False(structDefinitionSyntax.OpenBraceToken.IsMissing);
-            Assert.Equal(1, structDefinitionSyntax.OpenBraceToken.LeadingTrivia.Length);
+            Assert.Single(structDefinitionSyntax.OpenBraceToken.LeadingTrivia);
             Assert.False(structDefinitionSyntax.CloseBraceToken.IsMissing);
 
             Assert.False(typeDeclarationSyntax.SemicolonToken.IsMissing);
@@ -68,7 +68,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.False(structDefinitionSyntax.StructKeyword.IsMissing);
             Assert.False(structDefinitionSyntax.Name.IsMissing);
             Assert.False(structDefinitionSyntax.OpenBraceToken.IsMissing);
-            Assert.Equal(1, structDefinitionSyntax.OpenBraceToken.LeadingTrivia.Length);
+            Assert.Single(structDefinitionSyntax.OpenBraceToken.LeadingTrivia);
             Assert.False(structDefinitionSyntax.CloseBraceToken.IsMissing);
 
             Assert.False(typeDeclarationSyntax.SemicolonToken.IsMissing);
@@ -87,7 +87,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             AssertNodeKind(ast.ChildNodes[0], SyntaxKind.TypeDeclarationStatement);
             AssertNodeKind(ast.ChildNodes[1], SyntaxKind.EndOfFileToken);
             var eof = (SyntaxToken) ast.ChildNodes[1];
-            Assert.Equal(1, eof.LeadingTrivia.Length);
+            Assert.Single(eof.LeadingTrivia);
             Assert.Equal("b", eof.LeadingTrivia[0].ToString());
         }
 
@@ -114,7 +114,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(ast);
             Assert.Equal(1, ast.ChildNodes.Count);
             AssertNodeKind(ast.ChildNodes[0], SyntaxKind.EndOfFileToken);
-            Assert.Equal(1, ((SyntaxToken)ast.ChildNodes[0]).LeadingTrivia.Length);
+            Assert.Single(((SyntaxToken)ast.ChildNodes[0]).LeadingTrivia);
         }
 
         [Fact]
@@ -199,7 +199,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var sd = (VariableDeclarationStatementSyntax)ast.ChildNodes[0];
             Assert.False(sd.Declaration.IsMissing);
             Assert.Equal("SamplerState", sd.Declaration.Type.ToString());
-            Assert.Equal(1, sd.Declaration.Variables.Count);
+            Assert.Single(sd.Declaration.Variables);
             Assert.Equal("s", sd.Declaration.Variables[0].Identifier.ToString());
             Assert.Equal(SyntaxKind.StateInitializer, sd.Declaration.Variables[0].Initializer.Kind);
 
@@ -288,9 +288,9 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.False(sd.ParameterList.Parameters.GetSeparator(0).ContainsDiagnostics);
             Assert.False(sd.ParameterList.Parameters[1].ContainsDiagnostics);
             Assert.True(sd.ParameterList.Parameters.GetSeparator(1).ContainsDiagnostics);
-            Assert.Equal(1, ((SyntaxToken) sd.ParameterList.Parameters.GetSeparator(1)).LeadingTrivia.Length);
+            Assert.Single(((SyntaxToken) sd.ParameterList.Parameters.GetSeparator(1)).LeadingTrivia);
             Assert.Equal(SyntaxKind.SkippedTokensTrivia, ((SyntaxToken)sd.ParameterList.Parameters.GetSeparator(1)).LeadingTrivia[0].Kind);
-            Assert.Equal(1, ((SkippedTokensTriviaSyntax)((SyntaxToken)sd.ParameterList.Parameters.GetSeparator(1)).LeadingTrivia[0]).Tokens.Count);
+            Assert.Single(((SkippedTokensTriviaSyntax)((SyntaxToken)sd.ParameterList.Parameters.GetSeparator(1)).LeadingTrivia[0]).Tokens);
             Assert.Equal(SyntaxKind.IdentifierToken, ((SkippedTokensTriviaSyntax)((SyntaxToken)sd.ParameterList.Parameters.GetSeparator(1)).LeadingTrivia[0]).Tokens[0].Kind);
             Assert.Equal("b", ((SkippedTokensTriviaSyntax) ((SyntaxToken)sd.ParameterList.Parameters.GetSeparator(1)).LeadingTrivia[0]).Tokens[0].Text);
             Assert.False(sd.ParameterList.Parameters[2].ContainsDiagnostics);
@@ -317,7 +317,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.False(sd.ParameterList.Parameters.GetSeparator(0).ContainsDiagnostics);
             Assert.True(sd.ParameterList.Parameters[1].ContainsDiagnostics);
             Assert.False(sd.ParameterList.Parameters[1].Type.ContainsDiagnostics);
-            Assert.Equal(1, sd.ParameterList.Parameters[1].Declarator.Identifier.LeadingTrivia.Length);
+            Assert.Single(sd.ParameterList.Parameters[1].Declarator.Identifier.LeadingTrivia);
             Assert.Equal(SyntaxKind.SkippedTokensTrivia, sd.ParameterList.Parameters[1].Declarator.Identifier.LeadingTrivia[0].Kind);
             Assert.Equal(SyntaxKind.IntKeyword, ((SkippedTokensTriviaSyntax) sd.ParameterList.Parameters[1].Declarator.Identifier.LeadingTrivia[0]).Tokens[0].Kind);
             Assert.False(sd.ParameterList.Parameters.GetSeparator(1).ContainsDiagnostics);
@@ -346,7 +346,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal(2, ast.ChildNodes.Count);
             AssertNodeKind(ast.ChildNodes[0], SyntaxKind.VariableDeclarationStatement);
             var sd = (VariableDeclarationStatementSyntax)ast.ChildNodes[0];
-            Assert.Equal(1, sd.Declaration.Variables.Count);
+            Assert.Single(sd.Declaration.Variables);
             Assert.Equal(SyntaxKind.EqualsValueClause, sd.Declaration.Variables[0].Initializer.Kind);
             var initializer = (EqualsValueClauseSyntax) sd.Declaration.Variables[0].Initializer;
             Assert.False(initializer.EqualsToken.IsMissing);
@@ -368,7 +368,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal("main", sd.Name.ToString());
             Assert.False(sd.ParameterList.OpenParenToken.IsMissing);
             Assert.Empty(sd.ParameterList.Parameters);
-            Assert.Equal(1, sd.Body.Statements.Count);
+            Assert.Single(sd.Body.Statements);
             Assert.Equal(SyntaxKind.ForStatement, sd.Body.Statements[0].Kind);
             var forStatement = (ForStatementSyntax) sd.Body.Statements[0];
             Assert.NotNull(forStatement.Initializer);
@@ -395,7 +395,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal("main", sd.Name.ToString());
             Assert.False(sd.ParameterList.OpenParenToken.IsMissing);
             Assert.Empty(sd.ParameterList.Parameters);
-            Assert.Equal(1, sd.Body.Statements.Count);
+            Assert.Single(sd.Body.Statements);
             Assert.Equal(SyntaxKind.ForStatement, sd.Body.Statements[0].Kind);
             var forStatement = (ForStatementSyntax) sd.Body.Statements[0];
             Assert.NotNull(forStatement.Initializer);
@@ -416,8 +416,8 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var vds = (VariableDeclarationStatementSyntax)ast.ChildNodes[0];
             Assert.Equal("float", vds.Declaration.Type.ToString());
             Assert.True(vds.Declaration.Variables[0].Identifier.IsMissing);
-            Assert.Equal(1, vds.Declaration.Variables[0].Identifier.Diagnostics.Length);
-            Assert.Equal(1, vds.SemicolonToken.LeadingTrivia.Length);
+            Assert.Single(vds.Declaration.Variables[0].Identifier.Diagnostics);
+            Assert.Single(vds.SemicolonToken.LeadingTrivia);
             Assert.Equal(SyntaxKind.SkippedTokensTrivia, vds.SemicolonToken.LeadingTrivia[0].Kind);
             AssertNodeKind(ast.ChildNodes[1], SyntaxKind.VariableDeclarationStatement);
             AssertNodeKind(ast.ChildNodes[2], SyntaxKind.EndOfFileToken);
@@ -435,8 +435,8 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal("int", vds.Declaration.Type.ToString());
             Assert.False(vds.Declaration.Variables[0].Identifier.IsMissing);
             AssertNodeKind(ast.ChildNodes[1], SyntaxKind.EndOfFileToken);
-            Assert.Equal(1, ast.ChildNodes[1].Diagnostics.Length);
-            Assert.Equal(1, ((SyntaxToken) ast.ChildNodes[1]).LeadingTrivia.Length);
+            Assert.Single(ast.ChildNodes[1].Diagnostics);
+            Assert.Single(((SyntaxToken) ast.ChildNodes[1]).LeadingTrivia);
             Assert.Equal(SyntaxKind.SkippedTokensTrivia, ((SyntaxToken) ast.ChildNodes[1]).LeadingTrivia[0].Kind);
         }
 
@@ -449,10 +449,10 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal(2, ast.ChildNodes.Count);
             AssertNodeKind(ast.ChildNodes[0], SyntaxKind.VariableDeclarationStatement);
             var vds = (VariableDeclarationStatementSyntax)ast.ChildNodes[0];
-            Assert.Equal(1, vds.Declaration.Type.GetFirstTokenInDescendants().LeadingTrivia.Length);
+            Assert.Single(vds.Declaration.Type.GetFirstTokenInDescendants().LeadingTrivia);
             Assert.Equal(SyntaxKind.SkippedTokensTrivia, vds.Declaration.Type.GetFirstTokenInDescendants().LeadingTrivia[0].Kind);
             Assert.Equal(4, ((SkippedTokensTriviaSyntax) vds.Declaration.Type.GetFirstTokenInDescendants().LeadingTrivia[0]).Tokens.Count);
-            Assert.Equal(1, vds.Declaration.Type.GetFirstTokenInDescendants().Diagnostics.Length);
+            Assert.Single(vds.Declaration.Type.GetFirstTokenInDescendants().Diagnostics);
             Assert.Equal("Unexpected token '4'.", vds.Declaration.Type.GetFirstTokenInDescendants().Diagnostics[0].Message);
             AssertNodeKind(ast.ChildNodes[1], SyntaxKind.EndOfFileToken);
         }

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/ExpressionParsingTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/ExpressionParsingTests.cs
@@ -17,7 +17,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal(SyntaxKind.IdentifierName, expr.Kind);
             Assert.False(((IdentifierNameSyntax)expr).Name.IsMissing);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.ParenthesizedExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
         }
 
         [Theory]
@@ -43,7 +43,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             var opKind = SyntaxFacts.GetLiteralExpression(kind);
             Assert.Equal(opKind, expr.Kind);
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var us = (LiteralExpressionSyntax)expr;
             Assert.NotNull(us.Token);
             Assert.Equal(kind, us.Token.Kind);
@@ -57,9 +57,9 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.StringLiteralExpression, expr.Kind);
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var us = (StringLiteralExpressionSyntax)expr;
-            Assert.Equal(us.Tokens.Count, 1);
+            Assert.Single(us.Tokens);
             Assert.Equal(SyntaxKind.StringLiteralToken, us.Tokens[0].Kind);
         }
 
@@ -71,7 +71,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.NumericLiteralExpression, expr.Kind);
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var us = (LiteralExpressionSyntax)expr;
             Assert.NotNull(us.Token);
             Assert.Equal(SyntaxKind.IntegerLiteralToken, us.Token.Kind);
@@ -93,7 +93,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var opKind = SyntaxFacts.GetPrefixUnaryExpression(kind);
             Assert.Equal(opKind, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var us = (PrefixUnaryExpressionSyntax)expr;
             Assert.NotNull(us.OperatorToken);
             Assert.Equal(kind, us.OperatorToken.Kind);
@@ -114,7 +114,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var opKind = SyntaxFacts.GetPostfixUnaryExpression(kind);
             Assert.Equal(opKind, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var us = (PostfixUnaryExpressionSyntax)expr;
             Assert.NotNull(us.OperatorToken);
             Assert.Equal(kind, us.OperatorToken.Kind);
@@ -151,7 +151,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var opKind = SyntaxFacts.GetBinaryExpression(kind);
             Assert.Equal(opKind, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var b = (BinaryExpressionSyntax)expr;
             Assert.NotNull(b.OperatorToken);
             Assert.Equal(kind, b.OperatorToken.Kind);
@@ -182,7 +182,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             var opKind = SyntaxFacts.GetAssignmentExpression(kind);
             Assert.Equal(opKind, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var b = (AssignmentExpressionSyntax)expr;
             Assert.NotNull(b.OperatorToken);
             Assert.Equal(kind, b.OperatorToken.Kind);
@@ -201,7 +201,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.NotNull(expr);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var e = (FieldAccessExpressionSyntax)expr;
             Assert.NotNull(e.DotToken);
             Assert.Equal(kind, e.DotToken.Kind);
@@ -220,7 +220,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.ConditionalExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var ts = (ConditionalExpressionSyntax)expr;
             Assert.NotNull(ts.QuestionToken);
             Assert.NotNull(ts.ColonToken);
@@ -240,7 +240,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.CastExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var cs = (CastExpressionSyntax)expr;
             Assert.NotNull(cs.OpenParenToken);
             Assert.NotNull(cs.CloseParenToken);
@@ -261,7 +261,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.CastExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var cs = (CastExpressionSyntax) expr;
             Assert.NotNull(cs.OpenParenToken);
             Assert.NotNull(cs.CloseParenToken);
@@ -270,7 +270,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(cs.Type);
             Assert.NotNull(cs.Expression);
             Assert.Equal("uint", cs.Type.ToString());
-            Assert.Equal(1, cs.ArrayRankSpecifiers.Count);
+            Assert.Single(cs.ArrayRankSpecifiers);
             Assert.Equal("[a]", cs.ArrayRankSpecifiers[0].ToString());
             Assert.Equal("b", cs.Expression.ToString());
         }
@@ -284,7 +284,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.CastExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var cs = (CastExpressionSyntax) expr;
             Assert.NotNull(cs.OpenParenToken);
             Assert.NotNull(cs.CloseParenToken);
@@ -293,7 +293,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(cs.Type);
             Assert.NotNull(cs.Expression);
             Assert.Equal("uint", cs.Type.ToString());
-            Assert.Equal(1, cs.ArrayRankSpecifiers.Count);
+            Assert.Single(cs.ArrayRankSpecifiers);
             Assert.Equal("[4]", cs.ArrayRankSpecifiers[0].ToString());
             Assert.Equal("b", cs.Expression.ToString());
         }
@@ -307,14 +307,14 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.NumericConstructorInvocationExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var cs = (NumericConstructorInvocationExpressionSyntax)expr;
             Assert.NotNull(cs.ArgumentList.OpenParenToken);
             Assert.NotNull(cs.ArgumentList.CloseParenToken);
             Assert.False(cs.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(cs.ArgumentList.CloseParenToken.IsMissing);
             Assert.NotNull(cs.Type);
-            Assert.Equal(1, cs.ArgumentList.Arguments.Count);
+            Assert.Single(cs.ArgumentList.Arguments);
             Assert.Equal("int", cs.Type.ToString());
             Assert.Equal("b", cs.ArgumentList.Arguments[0].ToString());
         }
@@ -328,14 +328,14 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.FunctionInvocationExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var cs = (FunctionInvocationExpressionSyntax)expr;
             Assert.NotNull(cs.ArgumentList.OpenParenToken);
             Assert.NotNull(cs.ArgumentList.CloseParenToken);
             Assert.False(cs.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(cs.ArgumentList.CloseParenToken.IsMissing);
             Assert.NotNull(cs.Name);
-            Assert.Equal(0, cs.ArgumentList.Arguments.Count);
+            Assert.Empty(cs.ArgumentList.Arguments);
             Assert.Equal(SyntaxKind.IdentifierName, cs.Name.Kind);
             Assert.Equal("a", ((IdentifierNameSyntax) cs.Name).Name.Text);
         }
@@ -349,14 +349,14 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.MethodInvocationExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var cs = (MethodInvocationExpressionSyntax)expr;
             Assert.NotNull(cs.ArgumentList.OpenParenToken);
             Assert.NotNull(cs.ArgumentList.CloseParenToken);
             Assert.False(cs.ArgumentList.OpenParenToken.IsMissing);
             Assert.False(cs.ArgumentList.CloseParenToken.IsMissing);
             Assert.NotNull(cs.Name);
-            Assert.Equal(0, cs.ArgumentList.Arguments.Count);
+            Assert.Empty(cs.ArgumentList.Arguments);
             Assert.Equal("a", cs.Target.ToString());
             Assert.NotNull(cs.DotToken);
             Assert.Equal("b", cs.Name.Text);
@@ -371,7 +371,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.FunctionInvocationExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var cs = (FunctionInvocationExpressionSyntax)expr;
             Assert.NotNull(cs.ArgumentList.OpenParenToken);
             Assert.NotNull(cs.ArgumentList.CloseParenToken);
@@ -394,7 +394,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.MethodInvocationExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var cs = (MethodInvocationExpressionSyntax)expr;
             Assert.NotNull(cs.ArgumentList.OpenParenToken);
             Assert.NotNull(cs.ArgumentList.CloseParenToken);
@@ -419,7 +419,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.ElementAccessExpression, expr.Kind);
             Assert.Equal(text, expr.ToString());
-            Assert.Equal(0, expr.GetDiagnostics().Count());
+            Assert.Empty(expr.GetDiagnostics());
             var ea = (ElementAccessExpressionSyntax)expr;
             Assert.NotNull(ea.OpenBracketToken);
             Assert.NotNull(ea.CloseBracketToken);
@@ -473,7 +473,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             foreach (var diagnostic in expression.GetDiagnostics())
                 Debug.WriteLine(diagnostic.ToString());
-            Assert.Equal(0, expression.GetDiagnostics().Count());
+            Assert.Empty(expression.GetDiagnostics());
             Assert.Equal(text, expression.ToString());
 
             return (ExpressionSyntax) expression;

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/HlslLexerTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/HlslLexerTests.cs
@@ -26,7 +26,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal(new SourceRange(new SourceLocation(0), 1), allTokens[0].SourceRange);
             Assert.Equal(new SourceRange(new SourceLocation(0), 2), allTokens[0].FullSourceRange);
             Assert.Empty(allTokens[0].LeadingTrivia);
-            Assert.Equal(1, allTokens[0].TrailingTrivia.Length);
+            Assert.Single(allTokens[0].TrailingTrivia);
             Assert.Equal(new SourceRange(new SourceLocation(1), 1), allTokens[0].TrailingTrivia[0].SourceRange);
             Assert.Equal(SyntaxKind.WhitespaceTrivia, allTokens[0].TrailingTrivia[0].Kind);
             Assert.Equal(" ", ((SyntaxTrivia)allTokens[0].TrailingTrivia[0]).Text);
@@ -44,11 +44,11 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.Equal(new SourceRange(new SourceLocation(6), 1), allTokens[2].SourceRange);
             Assert.Equal(new SourceRange(new SourceLocation(5), 4), allTokens[2].FullSourceRange);
-            Assert.Equal(1, allTokens[2].LeadingTrivia.Length);
+            Assert.Single(allTokens[2].LeadingTrivia);
             Assert.Equal(new SourceRange(new SourceLocation(5), 1), allTokens[2].LeadingTrivia[0].SourceRange);
             Assert.Equal(SyntaxKind.WhitespaceTrivia, allTokens[2].LeadingTrivia[0].Kind);
             Assert.Equal(" ", ((SyntaxTrivia)allTokens[2].LeadingTrivia[0]).Text);
-            Assert.Equal(1, allTokens[2].TrailingTrivia.Length);
+            Assert.Single(allTokens[2].TrailingTrivia);
             Assert.Equal(new SourceRange(new SourceLocation(7), 2), allTokens[2].TrailingTrivia[0].SourceRange);
             Assert.Equal(SyntaxKind.WhitespaceTrivia, allTokens[2].TrailingTrivia[0].Kind);
             Assert.Equal("  ", ((SyntaxTrivia)allTokens[2].TrailingTrivia[0]).Text);
@@ -76,7 +76,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(token);
             Assert.Equal(SyntaxKind.IntegerLiteralToken, token.Kind);
             var errors = token.GetDiagnostics().ToArray();
-            Assert.Equal(0, errors.Length);
+            Assert.Empty(errors);
             Assert.Equal(text, token.Text);
             Assert.Equal(value, token.Value);
         }
@@ -94,7 +94,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(token);
             Assert.Equal(SyntaxKind.FloatLiteralToken, token.Kind);
             var errors = token.GetDiagnostics().ToArray();
-            Assert.Equal(0, errors.Length);
+            Assert.Empty(errors);
             Assert.Equal(text, token.Text);
             Assert.Equal(value, token.Value);
         }
@@ -113,7 +113,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
                 foreach (var diagnostic in token.GetDiagnostics())
                     Debug.WriteLine($"{diagnostic} at {diagnostic.SourceRange}");
 
-            Assert.False(tokens.Any(t => t.ContainsDiagnostics));
+            Assert.DoesNotContain(tokens, t => t.ContainsDiagnostics);
         }
 
         #region Test helpers

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
@@ -174,7 +174,7 @@ int i = TABLESIZE;
 
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("i", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
@@ -205,7 +205,7 @@ float g = FOO(3, 4);
 
             var varDeclStatement = (VariableDeclarationStatementSyntax) node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("f", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
@@ -260,7 +260,7 @@ FOO(1)
 
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("i", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
@@ -299,7 +299,7 @@ FOO(1)
 
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("i", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
@@ -351,7 +351,7 @@ PARAM(float, PASTE(bar, baz)) = 1.0f;
 
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("barbaz", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
@@ -381,7 +381,7 @@ FOO(Diffuse, texCoords.xy)
             var varDeclStatement1 = (VariableDeclarationStatementSyntax) node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedObjectType, varDeclStatement1.Declaration.Type.Kind);
             Assert.Equal("Texture2D", ((PredefinedObjectTypeSyntax) varDeclStatement1.Declaration.Type).ObjectTypeToken.Text);
-            Assert.Equal(1, varDeclStatement1.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement1.Declaration.Variables);
             Assert.Equal("g_DiffuseTexture", varDeclStatement1.Declaration.Variables[0].Identifier.Text);
             Assert.Null(varDeclStatement1.Declaration.Variables[0].Initializer);
 
@@ -389,7 +389,7 @@ FOO(Diffuse, texCoords.xy)
             var varDeclStatement2 = (VariableDeclarationStatementSyntax)node.ChildNodes[1];
             Assert.Equal(SyntaxKind.PredefinedObjectType, varDeclStatement2.Declaration.Type.Kind);
             Assert.Equal("SamplerState", ((PredefinedObjectTypeSyntax)varDeclStatement2.Declaration.Type).ObjectTypeToken.Text);
-            Assert.Equal(1, varDeclStatement2.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement2.Declaration.Variables);
             Assert.Equal("DiffuseSampler", varDeclStatement2.Declaration.Variables[0].Identifier.Text);
             Assert.Null(varDeclStatement2.Declaration.Variables[0].Initializer);
 
@@ -400,7 +400,7 @@ FOO(Diffuse, texCoords.xy)
             Assert.Equal(SyntaxKind.IdentifierDeclarationName, funcDefStatement.Name.Kind);
             Assert.Equal("GetTex", ((IdentifierDeclarationNameSyntax)funcDefStatement.Name).Name.Text);
 
-            Assert.Equal(1, funcDefStatement.Body.Statements.Count);
+            Assert.Single(funcDefStatement.Body.Statements);
             Assert.Equal(SyntaxKind.ReturnStatement, funcDefStatement.Body.Statements[0].Kind);
             var returnStatement = (ReturnStatementSyntax) funcDefStatement.Body.Statements[0];
             Assert.Equal(SyntaxKind.MethodInvocationExpression, returnStatement.Expression.Kind);
@@ -442,7 +442,7 @@ PARAM(float, PASTE(bar, FOO)) = 1.0f;
 
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("barFOO", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
@@ -472,7 +472,7 @@ float f = FOO(x, b);
 
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("f", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
@@ -503,7 +503,7 @@ Texture2D MyTex < TEX_COMP_FULL(dxt5, true) >;
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedObjectType, varDeclStatement.Declaration.Type.Kind);
             Assert.Equal(SyntaxKind.Texture2DKeyword, ((PredefinedObjectTypeSyntax) varDeclStatement.Declaration.Type).ObjectTypeToken.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("MyTex", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.Equal(2, varDeclStatement.Declaration.Variables[0].Annotations.Annotations.Count);
 
@@ -513,7 +513,7 @@ Texture2D MyTex < TEX_COMP_FULL(dxt5, true) >;
             Assert.NotNull(annotation1.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, annotation1.Declaration.Variables[0].Initializer.Kind);
             Assert.Equal(SyntaxKind.StringLiteralExpression, ((EqualsValueClauseSyntax) annotation1.Declaration.Variables[0].Initializer).Value.Kind);
-            Assert.Equal(1, ((StringLiteralExpressionSyntax)((EqualsValueClauseSyntax)annotation1.Declaration.Variables[0].Initializer).Value).Tokens.Count);
+            Assert.Single(((StringLiteralExpressionSyntax)((EqualsValueClauseSyntax)annotation1.Declaration.Variables[0].Initializer).Value).Tokens);
             Assert.Equal("\"dxt5\"", ((StringLiteralExpressionSyntax) ((EqualsValueClauseSyntax)annotation1.Declaration.Variables[0].Initializer).Value).Tokens[0].Text);
 
             var annotation2 = varDeclStatement.Declaration.Variables[0].Annotations.Annotations[1];
@@ -522,7 +522,7 @@ Texture2D MyTex < TEX_COMP_FULL(dxt5, true) >;
             Assert.NotNull(annotation2.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, annotation2.Declaration.Variables[0].Initializer.Kind);
             Assert.Equal(SyntaxKind.StringLiteralExpression, ((EqualsValueClauseSyntax)annotation2.Declaration.Variables[0].Initializer).Value.Kind);
-            Assert.Equal(1, ((StringLiteralExpressionSyntax)((EqualsValueClauseSyntax)annotation2.Declaration.Variables[0].Initializer).Value).Tokens.Count);
+            Assert.Single(((StringLiteralExpressionSyntax)((EqualsValueClauseSyntax)annotation2.Declaration.Variables[0].Initializer).Value).Tokens);
             Assert.Equal("\"true\"", ((StringLiteralExpressionSyntax)((EqualsValueClauseSyntax)annotation2.Declaration.Variables[0].Initializer).Value).Tokens[0].Text);
 
             Assert.Null(varDeclStatement.Declaration.Variables[0].Initializer);
@@ -546,9 +546,9 @@ string Bar = FOO(some/thing);
 
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, ((ScalarTypeSyntax) varDeclStatement.Declaration.Type).TypeTokens.Count);
+            Assert.Single(((ScalarTypeSyntax) varDeclStatement.Declaration.Type).TypeTokens);
             Assert.Equal("string", ((ScalarTypeSyntax) varDeclStatement.Declaration.Type).TypeTokens[0].Text);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("Bar", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
@@ -577,7 +577,7 @@ TEX2D(MyTexture);
 
             var varDeclStatement = (VariableDeclarationStatementSyntax)node.ChildNodes[0];
             Assert.Equal(SyntaxKind.PredefinedObjectType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
+            Assert.Single(varDeclStatement.Declaration.Variables);
             Assert.Equal("MyTexture2D", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.Null(varDeclStatement.Declaration.Variables[0].Initializer);
         }
@@ -903,11 +903,11 @@ int a;
             Assert.Equal(SyntaxKind.DisabledTextTrivia, allTokens[0].LeadingTrivia[2].Kind);
             Assert.Equal(SyntaxKind.ElseDirectiveTrivia, allTokens[0].LeadingTrivia[3].Kind);
             Assert.Equal(SyntaxKind.WhitespaceTrivia, allTokens[0].LeadingTrivia[4].Kind);
-            Assert.Equal(1, allTokens[0].TrailingTrivia.Length);
+            Assert.Single(allTokens[0].TrailingTrivia);
             Assert.Equal(SyntaxKind.IdentifierToken, allTokens[1].Kind);
             Assert.Equal(SyntaxKind.SemiToken, allTokens[2].Kind);
             Assert.Equal(SyntaxKind.EndOfFileToken, allTokens[3].Kind);
-            Assert.Equal(1, allTokens[3].LeadingTrivia.Length);
+            Assert.Single(allTokens[3].LeadingTrivia);
             Assert.Equal(SyntaxKind.EndIfDirectiveTrivia, allTokens[3].LeadingTrivia[0].Kind);
         }
 

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/StatementParsingTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/StatementParsingTests.cs
@@ -15,7 +15,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ExpressionStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var es = (ExpressionStatementSyntax)statement;
             Assert.NotNull(es.Expression);
@@ -34,7 +34,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ExpressionStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var es = (ExpressionStatementSyntax)statement;
             Assert.NotNull(es.Expression);
@@ -55,7 +55,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ExpressionStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var es = (ExpressionStatementSyntax)statement;
             Assert.NotNull(es.Expression);
@@ -78,12 +78,12 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ds = (VariableDeclarationStatementSyntax)statement;
             Assert.NotNull(ds.Declaration.Type);
             Assert.Equal("T", ds.Declaration.Type.ToString());
-            Assert.Equal(1, ds.Declaration.Variables.Count);
+            Assert.Single(ds.Declaration.Variables);
 
             Assert.NotNull(ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
@@ -102,17 +102,17 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ds = (VariableDeclarationStatementSyntax)statement;
             Assert.NotNull(ds.Declaration.Type);
             Assert.Equal("T", ds.Declaration.Type.ToString());
-            Assert.Equal(1, ds.Declaration.Variables.Count);
+            Assert.Single(ds.Declaration.Variables);
 
             Assert.NotNull(ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.Null(ds.Declaration.Variables[0].Initializer);
-            Assert.Equal(1, ds.Declaration.Variables[0].ArrayRankSpecifiers.Count);
+            Assert.Single(ds.Declaration.Variables[0].ArrayRankSpecifiers);
             Assert.Equal("2", ds.Declaration.Variables[0].ArrayRankSpecifiers[0].Dimension.ToString());
 
             Assert.NotNull(ds.SemicolonToken);
@@ -128,7 +128,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ds = (VariableDeclarationStatementSyntax)statement;
             Assert.NotNull(ds.Declaration.Type);
@@ -160,17 +160,17 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ds = (VariableDeclarationStatementSyntax)statement;
             Assert.NotNull(ds.Declaration.Type);
             Assert.Equal("T", ds.Declaration.Type.ToString());
-            Assert.Equal(1, ds.Declaration.Variables.Count);
+            Assert.Single(ds.Declaration.Variables);
 
             Assert.NotNull(ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(ds.Declaration.Variables[0].Initializer);
-            Assert.Equal(ds.Declaration.Variables[0].Initializer.Kind, SyntaxKind.EqualsValueClause);
+            Assert.Equal(SyntaxKind.EqualsValueClause, ds.Declaration.Variables[0].Initializer.Kind);
 
             var initializer = (EqualsValueClauseSyntax) ds.Declaration.Variables[0].Initializer;
             Assert.NotNull(initializer.EqualsToken);
@@ -191,7 +191,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ds = (VariableDeclarationStatementSyntax)statement;
             Assert.NotNull(ds.Declaration.Type);
@@ -200,7 +200,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.NotNull(ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
-            Assert.Equal(ds.Declaration.Variables[0].Initializer.Kind, SyntaxKind.EqualsValueClause);
+            Assert.Equal(SyntaxKind.EqualsValueClause, ds.Declaration.Variables[0].Initializer.Kind);
             var initializer = (EqualsValueClauseSyntax) ds.Declaration.Variables[0].Initializer;
             Assert.NotNull(initializer.EqualsToken);
             Assert.False(initializer.EqualsToken.IsMissing);
@@ -209,7 +209,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.NotNull(ds.Declaration.Variables[1].Identifier);
             Assert.Equal("b", ds.Declaration.Variables[1].Identifier.ToString());
-            Assert.Equal(ds.Declaration.Variables[1].Initializer.Kind, SyntaxKind.EqualsValueClause);
+            Assert.Equal(SyntaxKind.EqualsValueClause, ds.Declaration.Variables[1].Initializer.Kind);
             initializer = (EqualsValueClauseSyntax)ds.Declaration.Variables[1].Initializer;
             Assert.NotNull(initializer.EqualsToken);
             Assert.False(initializer.EqualsToken.IsMissing);
@@ -218,7 +218,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.NotNull(ds.Declaration.Variables[2].Identifier);
             Assert.Equal("c", ds.Declaration.Variables[2].Identifier.ToString());
-            Assert.Equal(ds.Declaration.Variables[2].Initializer.Kind, SyntaxKind.EqualsValueClause);
+            Assert.Equal(SyntaxKind.EqualsValueClause, ds.Declaration.Variables[2].Initializer.Kind);
             initializer = (EqualsValueClauseSyntax)ds.Declaration.Variables[2].Initializer;
             Assert.NotNull(initializer.EqualsToken);
             Assert.False(initializer.EqualsToken.IsMissing);
@@ -238,17 +238,17 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ds = (VariableDeclarationStatementSyntax)statement;
             Assert.NotNull(ds.Declaration.Type);
             Assert.Equal("T", ds.Declaration.Type.ToString());
-            Assert.Equal(1, ds.Declaration.Variables.Count);
+            Assert.Single(ds.Declaration.Variables);
 
             Assert.NotNull(ds.Declaration.Variables[0].Identifier);
             Assert.Equal("a", ds.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(ds.Declaration.Variables[0].Initializer);
-            Assert.Equal(ds.Declaration.Variables[0].Initializer.Kind, SyntaxKind.EqualsValueClause);
+            Assert.Equal(SyntaxKind.EqualsValueClause, ds.Declaration.Variables[0].Initializer.Kind);
             var initializer = (EqualsValueClauseSyntax)ds.Declaration.Variables[0].Initializer;
             Assert.NotNull(initializer.EqualsToken);
             Assert.False(initializer.EqualsToken.IsMissing);
@@ -270,7 +270,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.EmptyStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var es = (EmptyStatementSyntax)statement;
             Assert.NotNull(es.SemicolonToken);
@@ -286,7 +286,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.BreakStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var b = (BreakStatementSyntax)statement;
             Assert.NotNull(b.BreakKeyword);
@@ -305,7 +305,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ContinueStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var cs = (ContinueStatementSyntax)statement;
             Assert.NotNull(cs.ContinueKeyword);
@@ -324,7 +324,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.DiscardStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var cs = (DiscardStatementSyntax)statement;
             Assert.NotNull(cs.DiscardKeyword);
@@ -343,7 +343,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ReturnStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var rs = (ReturnStatementSyntax)statement;
             Assert.NotNull(rs.ReturnKeyword);
@@ -363,7 +363,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ReturnStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var rs = (ReturnStatementSyntax)statement;
             Assert.NotNull(rs.ReturnKeyword);
@@ -384,7 +384,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.WhileStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ws = (WhileStatementSyntax)statement;
             Assert.NotNull(ws.WhileKeyword);
@@ -406,7 +406,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.DoStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ds = (DoStatementSyntax)statement;
             Assert.NotNull(ds.DoKeyword);
@@ -431,7 +431,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -457,7 +457,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -468,7 +468,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(fs.Declaration);
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("T", fs.Declaration.Type.ToString());
-            Assert.Equal(1, fs.Declaration.Variables.Count);
+            Assert.Single(fs.Declaration.Variables);
             Assert.NotNull(fs.Declaration.Variables[0].Identifier);
             Assert.Equal("a", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
@@ -495,7 +495,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -542,7 +542,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -572,7 +572,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -607,7 +607,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -637,7 +637,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -668,7 +668,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -703,7 +703,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var fs = (ForStatementSyntax)statement;
             Assert.NotNull(fs.ForKeyword);
@@ -714,7 +714,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(fs.Declaration);
             Assert.NotNull(fs.Declaration.Type);
             Assert.Equal("T", fs.Declaration.Type.ToString());
-            Assert.Equal(1, fs.Declaration.Variables.Count);
+            Assert.Single(fs.Declaration.Variables);
             Assert.NotNull(fs.Declaration.Variables[0].Identifier);
             Assert.Equal("a", fs.Declaration.Variables[0].Identifier.ToString());
             Assert.NotNull(fs.Declaration.Variables[0].Initializer);
@@ -748,7 +748,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.IfStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ss = (IfStatementSyntax)statement;
             Assert.NotNull(ss.IfKeyword);
@@ -771,7 +771,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.IfStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ss = (IfStatementSyntax)statement;
             Assert.NotNull(ss.IfKeyword);
@@ -797,7 +797,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.SwitchStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ss = (SwitchStatementSyntax)statement;
             Assert.NotNull(ss.SwitchKeyword);
@@ -807,7 +807,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal("a", ss.Expression.ToString());
             Assert.NotNull(ss.CloseParenToken);
             Assert.NotNull(ss.OpenBraceToken);
-            Assert.Equal(0, ss.Sections.Count);
+            Assert.Empty(ss.Sections);
             Assert.NotNull(ss.CloseBraceToken);
         }
 
@@ -820,7 +820,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.SwitchStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ss = (SwitchStatementSyntax)statement;
             Assert.NotNull(ss.SwitchKeyword);
@@ -831,8 +831,8 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(ss.CloseParenToken);
             Assert.NotNull(ss.OpenBraceToken);
 
-            Assert.Equal(1, ss.Sections.Count);
-            Assert.Equal(1, ss.Sections[0].Labels.Count);
+            Assert.Single(ss.Sections);
+            Assert.Single(ss.Sections[0].Labels);
             Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[0].Labels[0].Keyword.Kind);
             var caseLabelSyntax = ss.Sections[0].Labels[0] as CaseSwitchLabelSyntax;
@@ -840,7 +840,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(caseLabelSyntax.Value);
             Assert.Equal("b", caseLabelSyntax.Value.ToString());
             Assert.NotNull(caseLabelSyntax.ColonToken);
-            Assert.Equal(1, ss.Sections[0].Statements.Count);
+            Assert.Single(ss.Sections[0].Statements);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
             Assert.NotNull(ss.CloseBraceToken);
@@ -855,7 +855,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.SwitchStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ss = (SwitchStatementSyntax)statement;
             Assert.NotNull(ss.SwitchKeyword);
@@ -868,7 +868,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
             Assert.Equal(2, ss.Sections.Count);
 
-            Assert.Equal(1, ss.Sections[0].Labels.Count);
+            Assert.Single(ss.Sections[0].Labels);
             Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[0].Labels[0].Keyword.Kind);
             var caseLabelSyntax = ss.Sections[0].Labels[0] as CaseSwitchLabelSyntax;
@@ -876,10 +876,10 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(caseLabelSyntax.Value);
             Assert.Equal("b", caseLabelSyntax.Value.ToString());
             Assert.NotNull(caseLabelSyntax.ColonToken);
-            Assert.Equal(1, ss.Sections[0].Statements.Count);
+            Assert.Single(ss.Sections[0].Statements);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
-            Assert.Equal(1, ss.Sections[1].Labels.Count);
+            Assert.Single(ss.Sections[1].Labels);
             Assert.NotNull(ss.Sections[1].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[1].Labels[0].Keyword.Kind);
             var caseLabelSyntax2 = ss.Sections[1].Labels[0] as CaseSwitchLabelSyntax;
@@ -887,7 +887,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(caseLabelSyntax2.Value);
             Assert.Equal("c", caseLabelSyntax2.Value.ToString());
             Assert.NotNull(caseLabelSyntax2.ColonToken);
-            Assert.Equal(1, ss.Sections[1].Statements.Count);
+            Assert.Single(ss.Sections[1].Statements);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
             Assert.NotNull(ss.CloseBraceToken);
@@ -902,7 +902,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.SwitchStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ss = (SwitchStatementSyntax)statement;
             Assert.NotNull(ss.SwitchKeyword);
@@ -913,14 +913,14 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(ss.CloseParenToken);
             Assert.NotNull(ss.OpenBraceToken);
 
-            Assert.Equal(1, ss.Sections.Count);
+            Assert.Single(ss.Sections);
 
-            Assert.Equal(1, ss.Sections[0].Labels.Count);
+            Assert.Single(ss.Sections[0].Labels);
             Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.DefaultKeyword, ss.Sections[0].Labels[0].Keyword.Kind);
             Assert.Equal(SyntaxKind.DefaultSwitchLabel, ss.Sections[0].Labels[0].Kind);
             Assert.NotNull(ss.Sections[0].Labels[0].ColonToken);
-            Assert.Equal(1, ss.Sections[0].Statements.Count);
+            Assert.Single(ss.Sections[0].Statements);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
             Assert.NotNull(ss.CloseBraceToken);
@@ -935,7 +935,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.SwitchStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ss = (SwitchStatementSyntax)statement;
             Assert.NotNull(ss.SwitchKeyword);
@@ -946,7 +946,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(ss.CloseParenToken);
             Assert.NotNull(ss.OpenBraceToken);
 
-            Assert.Equal(1, ss.Sections.Count);
+            Assert.Single(ss.Sections);
 
             Assert.Equal(2, ss.Sections[0].Labels.Count);
             Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
@@ -962,7 +962,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(caseLabelSyntax2.Value);
             Assert.Equal("c", caseLabelSyntax2.Value.ToString());
             Assert.NotNull(ss.Sections[0].Labels[0].ColonToken);
-            Assert.Equal(1, ss.Sections[0].Statements.Count);
+            Assert.Single(ss.Sections[0].Statements);
             Assert.Equal(";", ss.Sections[0].Statements[0].ToString());
 
             Assert.NotNull(ss.CloseBraceToken);
@@ -977,7 +977,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.SwitchStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var ss = (SwitchStatementSyntax)statement;
             Assert.NotNull(ss.SwitchKeyword);
@@ -988,9 +988,9 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(ss.CloseParenToken);
             Assert.NotNull(ss.OpenBraceToken);
 
-            Assert.Equal(1, ss.Sections.Count);
+            Assert.Single(ss.Sections);
 
-            Assert.Equal(1, ss.Sections[0].Labels.Count);
+            Assert.Single(ss.Sections[0].Labels);
             Assert.NotNull(ss.Sections[0].Labels[0].Keyword);
             Assert.Equal(SyntaxKind.CaseKeyword, ss.Sections[0].Labels[0].Keyword.Kind);
             var caseLabelSyntax = ss.Sections[0].Labels[0] as CaseSwitchLabelSyntax;
@@ -1013,10 +1013,10 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.Block, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var block = (BlockSyntax) statement;
-            Assert.Equal(1, block.Statements.Count);
+            Assert.Single(block.Statements);
             var innerStatement = block.Statements[0];
             Assert.NotNull(innerStatement);
             Assert.Equal(SyntaxKind.ExpressionStatement, innerStatement.Kind);
@@ -1038,7 +1038,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.TypeDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var typeDeclarationStatement = (TypeDeclarationStatementSyntax) statement;
             Assert.Equal(SyntaxKind.ClassType, typeDeclarationStatement.Type.Kind);
@@ -1049,7 +1049,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal(SyntaxKind.ClassKeyword, cd.StructKeyword.Kind);
             Assert.Null(cd.BaseList);
             Assert.NotNull(cd.OpenBraceToken);
-            Assert.Equal(1, cd.Members.Count);
+            Assert.Single(cd.Members);
             Assert.Equal("int a;", cd.Members[0].ToString());
             Assert.NotNull(cd.CloseBraceToken);
 
@@ -1065,7 +1065,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.TypeDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var typeDeclarationStatement = (TypeDeclarationStatementSyntax)statement;
             Assert.Equal(SyntaxKind.ClassType, typeDeclarationStatement.Type.Kind);
@@ -1078,7 +1078,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(cd.BaseList.ColonToken);
             Assert.Equal("B", cd.BaseList.BaseType.ToString());
             Assert.NotNull(cd.OpenBraceToken);
-            Assert.Equal(1, cd.Members.Count);
+            Assert.Single(cd.Members);
             Assert.Equal("int a;", cd.Members[0].ToString());
             Assert.NotNull(cd.CloseBraceToken);
 
@@ -1094,7 +1094,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.TypeDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var typeDeclarationStatement = (TypeDeclarationStatementSyntax)statement;
             Assert.Equal(SyntaxKind.InterfaceType, typeDeclarationStatement.Type.Kind);
@@ -1104,7 +1104,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal("I", cd.Name.Text);
             Assert.Equal(SyntaxKind.InterfaceKeyword, cd.InterfaceKeyword.Kind);
             Assert.NotNull(cd.OpenBraceToken);
-            Assert.Equal(1, cd.Methods.Count);
+            Assert.Single(cd.Methods);
             Assert.Equal("int foo();", cd.Methods[0].ToString());
             Assert.NotNull(cd.CloseBraceToken);
 
@@ -1120,7 +1120,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.TypeDeclarationStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var typeDeclarationStatement = (TypeDeclarationStatementSyntax)statement;
             Assert.Equal(SyntaxKind.StructType, typeDeclarationStatement.Type.Kind);
@@ -1130,7 +1130,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal("S", cd.Name.Text);
             Assert.Equal(SyntaxKind.StructKeyword, cd.StructKeyword.Kind);
             Assert.NotNull(cd.OpenBraceToken);
-            Assert.Equal(1, cd.Members.Count);
+            Assert.Single(cd.Members);
             Assert.Equal("int a;", cd.Members[0].ToString());
             Assert.NotNull(cd.CloseBraceToken);
 
@@ -1146,7 +1146,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.TypedefStatement, statement.Kind);
             Assert.Equal(text, statement.ToString());
-            Assert.Equal(0, statement.GetDiagnostics().Count());
+            Assert.Empty(statement.GetDiagnostics());
 
             var typedefStatement = (TypedefStatementSyntax) statement;
             Assert.Equal(SyntaxKind.PredefinedVectorType, typedefStatement.Type.Kind);

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Syntax/SyntaxTreeTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Syntax/SyntaxTreeTests.cs
@@ -140,7 +140,7 @@ float b;
             };
             var syntaxTree = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(code), "__Root__.hlsl"), options);
 
-            Assert.Equal(1, syntaxTree.GetDiagnostics().Count());
+            Assert.Single(syntaxTree.GetDiagnostics());
         }
 
         private static SyntaxTree CreateSyntaxTree()


### PR DESCRIPTION
Hello

Since compiling from source was giving a lot of Warnings from Unit Tests (mostly Single or Empty collection count),

This part should now be warning free.

Thanks