### PR TITLE
Namespaces handling improvements. Share methods between the same name scopes. Do not lookup upper scope for qualified name.

### DIFF
--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Binding/FunctionDeclarationTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Binding/FunctionDeclarationTests.cs
@@ -24,6 +24,157 @@ void foo() {}";
         }
 
         [Fact]
+        public void AllowsNamespaceFunctionOverloads()
+        {
+            var code = @"
+namespace Shading { void foo(int x) {} }
+namespace Shading { void foo() {} }
+namespace Culling { namespace Decals { void foo(int x) {} } }
+namespace Culling { namespace Decals { void foo() {} } }
+namespace Shading { namespace Decals { void foo(int x) {} } }
+namespace Shading { namespace Decals { void foo() {} } }
+namespace Culling { void foo(int x) {} }
+namespace Culling { void foo() {} }";
+            AssertNoDiagnostics(code);
+        }
+
+        [Fact]
+        public void DetectsNamespaceFunctionRedefinition()
+        {
+            var code = @"
+namespace Shading { void foo() {} }
+namespace Shading { void foo() {} }
+namespace Shading { namespace Decals { void foo() {} } }
+namespace Shading { namespace Decals { void foo() {} } }";
+            AssertDiagnostics(code, DiagnosticId.SymbolRedefined, DiagnosticId.SymbolRedefined);
+        }
+
+        [Fact]
+        public void DetectsNamespaceMissingFunctionDeclaration()
+        {
+            var code = @"
+namespace Shading {
+    void foo();
+    namespace Decals {}
+}
+
+void main()
+{
+    Shading::Decals::foo2();
+    Shading::Decals::foo();
+    Shading::foo();
+}";
+            AssertDiagnostics(code, DiagnosticId.UndeclaredFunction, DiagnosticId.UndeclaredFunction, DiagnosticId.FunctionMissingImplementation);
+        }
+
+        [Fact]
+        public void DetectsNamespaceMissingVariableDeclaration()
+        {
+            var code = @"
+namespace Shading {
+    static const uint x1 = 1;
+    namespace Decals {}
+}
+
+void main()
+{
+    uint x;
+    x = Shading::Decals::y1;
+    x = Shading::Decals::x1;
+    x = Shading::x1;
+}";
+            AssertDiagnostics(code, DiagnosticId.UndeclaredVariable, DiagnosticId.UndeclaredVariable);
+        }
+
+#if false
+        [Fact]
+        public void AllowsNesterNamespaceFunctionDeclarations()
+        {
+            var code = @"
+namespace Shading { void foo() {} }
+namespace Shading { namespace Shading { void foo() {} } }";
+            AssertNoDiagnostics(code);
+        }
+#endif
+
+        [Fact]
+        public void DetectsNesterNamespaceFunctionRedefinition()
+        {
+            var code = @"
+namespace Shading {
+    namespace Shading { void foo() {} }
+    namespace Shading { void foo() {} }
+}";
+            AssertDiagnostics(code, DiagnosticId.SymbolRedefined);
+        }
+
+        [Fact]
+        public void AllowsMultiNamespaceFunctionDeclarations()
+        {
+            var code = @"
+namespace Shading { void foo(int x) {} }
+namespace Shading { void foo() {} }
+void foo(uint i) { Shading::foo(); }
+namespace Shading { void foo2() {} }
+namespace Shading { namespace Decals { void foo(uint i) {} } }
+namespace Shading { namespace Decals { void foo2() { foo(1.0); } } }
+
+void main()
+{
+    foo(1.0);
+    Shading::foo(1.0);
+    Shading::foo2();
+    Shading::Decals::foo(1.0);
+    Shading::Decals::foo2();
+}";
+            AssertNoDiagnostics(code);
+        }
+
+        [Fact]
+        public void AllowsMultiNamespaceVariableDeclarations()
+        {
+            var code = @"
+namespace Shading { static const uint x1 = 1; }
+namespace Shading { static const uint x2 = 2; }
+namespace Shading { static const uint x3 = 3; }
+namespace Shading { namespace Decals { static const uint y1 = 1; } }
+namespace Shading { namespace Decals { static const uint y2 = 2; } }
+namespace Shading { namespace Decals { static const uint y3 = 3; } }
+
+void main()
+{
+    uint x;
+    x = Shading::x1;
+    x = Shading::x2;
+    x = Shading::x3;
+    x = Shading::Decals::y1;
+    x = Shading::Decals::y2;
+    x = Shading::Decals::y3;
+}";
+            AssertNoDiagnostics(code);
+        }
+
+        [Fact]
+        public void DetectsMultiNamespaceAmbiguousFunctionInvocation()
+        {
+            var code = @"
+namespace Shading { void foo(int i) {} }
+namespace Shading { void foo(uint i) {} }
+namespace Culling { namespace Decals { void foo(int i) {} } }
+namespace Culling { namespace Decals { void foo(uint i) {} } }
+namespace Shading { namespace Decals { void foo(int i) {} } }
+namespace Shading { namespace Decals { void foo(uint i) {} } }
+
+void main()
+{
+    Shading::foo(1.0);
+    Culling::Decals::foo(1.0);
+    Shading::Decals::foo(1.0);
+}";
+            AssertDiagnostics(code, DiagnosticId.AmbiguousInvocation, DiagnosticId.AmbiguousInvocation, DiagnosticId.AmbiguousInvocation);
+        }
+
+        [Fact]
         public void AllowsMultipleMatchingFunctionDeclarations()
         {
             var code = @"
@@ -88,7 +239,7 @@ DECLARE_FUNC(myfunc)
 
 void main()
 {
-	myfunc();
+    myfunc();
 }
 ";
             AssertNoDiagnostics(code);
@@ -107,8 +258,8 @@ void main()
             var code = "int foo() { return; }";
             AssertDiagnostics(code, DiagnosticId.RetObjectRequired);
         }
-	
-	[Fact]
+
+        [Fact]
         public void DetectsMissingReturnStatementFromNonVoidFunction()
         {
             var code = "int foo() { }";

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Binding/Binder.Declarations.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Binding/Binder.Declarations.cs
@@ -97,9 +97,17 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Binding
             var enclosingNamespace = LookupEnclosingNamespace();
             var namespaceSymbol = new NamespaceSymbol(declaration, enclosingNamespace);
 
-            AddSymbol(namespaceSymbol, declaration.Name.SourceRange);
+            // the same as LookupNamespaceOrClass but only for namespace
+            var previousNamespaceSymbol = LookupSymbols<NamespaceSymbol>(declaration.Name).FirstOrDefault();
 
-            var namespaceBinder = new NamespaceBinder(_sharedBinderState, this, namespaceSymbol);
+            AddSymbol(namespaceSymbol, declaration.Name.SourceRange, true);
+
+            NamespaceBinder namespaceBinder;
+            if (previousNamespaceSymbol != null)
+                namespaceBinder = previousNamespaceSymbol.Binder as NamespaceBinder;
+            else
+                namespaceBinder = new NamespaceBinder(_sharedBinderState, this, namespaceSymbol);
+
             namespaceSymbol.Binder = namespaceBinder;
 
             var boundDeclarations = namespaceBinder.BindTopLevelDeclarations(declaration.Declarations, namespaceSymbol);

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Binding/Binder.Expressions.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Binding/Binder.Expressions.cs
@@ -41,7 +41,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Binding
                     return BindPrefixUnaryExpression((PrefixUnaryExpressionSyntax) node);
                 case SyntaxKind.PostDecrementExpression:
                 case SyntaxKind.PostIncrementExpression:
-                    return BindPostfixUnaryExpression((PostfixUnaryExpressionSyntax)node);
+                    return BindPostfixUnaryExpression((PostfixUnaryExpressionSyntax) node);
                 case SyntaxKind.AddExpression:
                 case SyntaxKind.MultiplyExpression:
                 case SyntaxKind.SubtractExpression:
@@ -258,13 +258,13 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Binding
         private BoundExpression BindAssignmentExpression(AssignmentExpressionSyntax node)
         {
             // TODO: Need to apply similar overload resolution as BindBinaryExpression.
-            var operatorKind = (node.Kind != SyntaxKind.SimpleAssignmentExpression) 
-                ? (BinaryOperatorKind?) SyntaxFacts.GetBinaryOperatorKind(node.Kind) 
+            var operatorKind = (node.Kind != SyntaxKind.SimpleAssignmentExpression)
+                ? (BinaryOperatorKind?) SyntaxFacts.GetBinaryOperatorKind(node.Kind)
                 : null;
 
             return new BoundAssignmentExpression(
-                Bind(node.Left, BindExpression), 
-                operatorKind, 
+                Bind(node.Left, BindExpression),
+                operatorKind,
                 Bind(node.Right, BindExpression));
         }
 
@@ -514,7 +514,11 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Binding
                     throw new InvalidOperationException();
             }
 
-            var result = (containerSymbol?.Binder ?? this).LookupFunction(actualName, argumentTypes);
+            OverloadResolutionResult<FunctionSymbolSignature> result;
+            if (containerSymbol != null && containerSymbol.Binder != null)
+                result = containerSymbol.Binder.LookupFunction(containerSymbol, actualName, argumentTypes);
+            else
+                result = LookupFunction(actualName, argumentTypes);
 
             if (result.Best == null)
             {


### PR DESCRIPTION
I have no idea what I'm doing, I have paws, but I fixed it.

- Enable `allowDuplicates` for namespace symbols, so you can declare multiple namespaces with the same name. No more "redefinition" error.
- Reuse the `NamespaceBinder` of the first namespace with the current name, so you can share methods between all scopes.
- When lookup namespace container use the **Last** one, because it has all members. So don't report "ambiguous" error in that case.
- Don't extrapolate function lookup to the upper scope for a qualified name, like invoke `Shading::Decals::foo` but get `Shading::foo`. Actually we need to check members in the container only, not in the whole binder tree.
- Lots of tests for the namespace behavior. Correlates with the latest DXC release.

**Known issues:**
I didn't touch anything with `struct`, `enum` scopes. Probably it has similar issues.
Don't use nested namespaces with the same name, like `namespace Shading { namespace Shading {} }` it doesn't work properly.

example
```hlsl
namespace Shading { void foo(int x) {} }
namespace Shading { void foo() {} }
namespace Culling { namespace Decals { void foo(int x) {} } }
namespace Culling { namespace Decals { void foo() {} } }
```