### PR TITLE
#224 #231 Macro VariadicArgument operator improves with stringification.

### DIFF
--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
@@ -599,8 +599,8 @@ string Bar = STRING(7, Pass, 8);
 
             TestRoundTripping(node, text);
             VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive, Text = "CTR" },
                 new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive, Text = "CTR3" },
-                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive, Text = "CTR2" },
                 new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive, Text = "CTR_WTF" },
                 new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive, Text = "STRING" });
 
@@ -612,15 +612,15 @@ string Bar = STRING(7, Pass, 8);
             Assert.Equal(SyntaxKind.VariableDeclarationStatement, ((SyntaxNode) node.ChildNodes[4]).Kind);
 
             var varDeclStatement = (VariableDeclarationStatementSyntax) node.ChildNodes[0];
-            Assert.Equal(SyntaxKind.PredefinedVectorType, varDeclStatement.Declaration.Type.Kind);
-            Assert.Equal("float", ((VectorTypeSyntax) varDeclStatement.Declaration.Type).TypeToken.Text);
+            Assert.Equal(SyntaxKind.PredefinedScalarType, varDeclStatement.Declaration.Type.Kind);
+            Assert.Equal("float", ((ScalarTypeSyntax) varDeclStatement.Declaration.Type).TypeTokens[0].Text);
             Assert.Equal(1, varDeclStatement.Declaration.Variables.Count);
             Assert.Equal("x", varDeclStatement.Declaration.Variables[0].Identifier.Text);
             Assert.NotNull(varDeclStatement.Declaration.Variables[0].Initializer);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement.Declaration.Variables[0].Initializer.Kind);
 
             var equalsValueClause = (EqualsValueClauseSyntax) varDeclStatement.Declaration.Variables[0].Initializer;
-            Assert.Equal(SyntaxKind.NumericConstructorInvocationExpression, equalsValueClause.Value.Kind);
+            Assert.Equal(SyntaxKind.ArrayInitializerExpression, equalsValueClause.Value.Kind);
 
             var varDeclStatement2 = (VariableDeclarationStatementSyntax) node.ChildNodes[1];
             Assert.Equal(SyntaxKind.PredefinedVectorType, varDeclStatement2.Declaration.Type.Kind);
@@ -631,7 +631,7 @@ string Bar = STRING(7, Pass, 8);
             Assert.Equal(SyntaxKind.EqualsValueClause, varDeclStatement2.Declaration.Variables[0].Initializer.Kind);
 
             var equalsValueClause2 = (EqualsValueClauseSyntax) varDeclStatement2.Declaration.Variables[0].Initializer;
-            Assert.Equal(SyntaxKind.NumericConstructorInvocationExpression, equalsValueClause2.Value.Kind);
+            Assert.Equal(SyntaxKind.ArrayInitializerExpression, equalsValueClause2.Value.Kind);
 
             var varDeclStatement3 = (VariableDeclarationStatementSyntax) node.ChildNodes[2];
             Assert.Equal(SyntaxKind.PredefinedVectorType, varDeclStatement3.Declaration.Type.Kind);

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Diagnostics/DiagnosticId.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Diagnostics/DiagnosticId.cs
@@ -25,7 +25,6 @@
         IncludeNotFound,
         IncludeUnexpectedError,
         NotEnoughMacroParameters,
-        NoVariadicArgumentParameter,
         UnexpectedAttribute,
 
         InvalidExprTerm,

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Diagnostics/DiagnosticId.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Diagnostics/DiagnosticId.cs
@@ -25,6 +25,7 @@
         IncludeNotFound,
         IncludeUnexpectedError,
         NotEnoughMacroParameters,
+        NoVariadicArgumentParameter,
         UnexpectedAttribute,
 
         InvalidExprTerm,

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Parser/DirectiveParser.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Parser/DirectiveParser.cs
@@ -205,6 +205,10 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
                 {
                     paramList.Add(NextToken().WithKind(SyntaxKind.IdentifierToken));
                 }
+                else if (Current.Kind == SyntaxKind.EllipsisToken)
+                {
+                    paramList.Add(Match(SyntaxKind.EllipsisToken));
+                }
                 else
                 {
                     paramList.Add(Match(SyntaxKind.IdentifierToken));
@@ -216,6 +220,10 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
 
                     switch (Current.Kind)
                     {
+                        case SyntaxKind.EllipsisToken:
+                            paramList.Add(Match(SyntaxKind.EllipsisToken));
+                            break;
+
                         case SyntaxKind.IdentifierToken:
                             paramList.Add(Match(SyntaxKind.IdentifierToken));
                             break;

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.cs
@@ -670,8 +670,24 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
                         ReadNumber();
                     else
                     {
-                        _kind = SyntaxKind.DotToken;
                         NextChar();
+                        if (_charReader.Current == '.')
+                        {
+                            NextChar();
+                            if (_charReader.Current == '.')
+                            {
+                                _kind = SyntaxKind.EllipsisToken;
+                                NextChar();
+                            }
+                            else
+                            {
+                                _kind = SyntaxKind.DotDotToken;
+                            }
+                        }
+                        else
+                        {
+                            _kind = SyntaxKind.DotToken;
+                        }
                     }
                     break;
 

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Parser/MacroArgumentsParser.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Parser/MacroArgumentsParser.cs
@@ -39,6 +39,10 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
                             parenStack--;
                             currentArg.Add(NextToken());
                             break;
+                        case SyntaxKind.EllipsisToken:
+                            arguments.Add(Match(SyntaxKind.EllipsisToken));
+                            currentArg.Add(NextToken());
+                            break;
                         case SyntaxKind.CommaToken:
                             if (CommaIsSeparatorStack.Peek() == false)
                                 goto default;

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxFacts.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxFacts.cs
@@ -2852,6 +2852,8 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
                     return SyntaxKind.MessageKeyword;
                 case "pack_matrix":
                     return SyntaxKind.PackMatrixKeyword;
+                case "__VA_ARGS__":
+                    return SyntaxKind.VariadicArgumentKeyword;
                 case "warning":
                     return SyntaxKind.WarningKeyword;
                 default:
@@ -2879,6 +2881,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
                 case SyntaxKind.DefKeyword:
                 case SyntaxKind.MessageKeyword:
                 case SyntaxKind.PackMatrixKeyword:
+                case SyntaxKind.VariadicArgumentKeyword:
                 case SyntaxKind.WarningKeyword:
                     return true;
 

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxFacts.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxFacts.cs
@@ -1368,12 +1368,12 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
                 case SyntaxKind.Half4x2Keyword:
                 case SyntaxKind.Half4x3Keyword:
                 case SyntaxKind.Half4x4Keyword:
-				case SyntaxKind.Float16_tKeyword:
-				case SyntaxKind.Float16_t1Keyword:
-				case SyntaxKind.Float16_t2Keyword:
-				case SyntaxKind.Float16_t3Keyword:
-				case SyntaxKind.Float16_t4Keyword:
-				case SyntaxKind.Float16_t1x1Keyword:
+                case SyntaxKind.Float16_tKeyword:
+                case SyntaxKind.Float16_t1Keyword:
+                case SyntaxKind.Float16_t2Keyword:
+                case SyntaxKind.Float16_t3Keyword:
+                case SyntaxKind.Float16_t4Keyword:
+                case SyntaxKind.Float16_t1x1Keyword:
                 case SyntaxKind.Float16_t1x2Keyword:
                 case SyntaxKind.Float16_t1x3Keyword:
                 case SyntaxKind.Float16_t1x4Keyword:
@@ -2852,10 +2852,10 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
                     return SyntaxKind.MessageKeyword;
                 case "pack_matrix":
                     return SyntaxKind.PackMatrixKeyword;
-                case "__VA_ARGS__":
-                    return SyntaxKind.VariadicArgumentKeyword;
                 case "warning":
                     return SyntaxKind.WarningKeyword;
+                case "__VA_ARGS__":
+                    return SyntaxKind.VariadicArgumentKeyword;
                 default:
                     return SyntaxKind.IdentifierToken;
             }
@@ -2881,8 +2881,8 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
                 case SyntaxKind.DefKeyword:
                 case SyntaxKind.MessageKeyword:
                 case SyntaxKind.PackMatrixKeyword:
-                case SyntaxKind.VariadicArgumentKeyword:
                 case SyntaxKind.WarningKeyword:
+                case SyntaxKind.VariadicArgumentKeyword:
                     return true;
 
                 default:

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxKind.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxKind.cs
@@ -457,6 +457,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
         Uint16_t4x2Keyword,
         Uint16_t4x3Keyword,
         Uint16_t4x4Keyword,
+        VariadicArgumentKeyword,
         VectorKeyword,
         VertexShaderKeyword,
         VerticesKeyword,
@@ -518,6 +519,8 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
         EqualsEqualsToken,
         ExclamationEqualsToken,
         DotToken,
+        DotDotToken,
+        EllipsisToken,
         HashToken,
         HashHashToken,
 


### PR DESCRIPTION
Based on @Jasonchan35 pull request.

- Checking `token.ContextualKind` instead of `token.Kind`.
- Insert commas between variadic arguments into the parsing result list.
- Don't report missing localize string `NoVariadicArgumentParameter` (causes a crash lol). Instead let the parser make the decision.
- So macro **parameter** name `__VA_ARGS__` consider to be valid. It doesn't actually have to be an ellipsis `...`.
- Add stringification operation for variadic operator `#__VA_ARGS__`.
- Huge variadic operator test with stringification and keyword as parameter. Correlates with the latest DXC release.
- Tiny test for stringify with skipped parameters because I wanted to make sure.

```hlsl
#define CTR(...) = {__VA_ARGS__}
#define CTR3(x, ...) = float3(x, __VA_ARGS__)
float x CTR(0.0f);
float3 y CTR(1.0f, 2.0f, 3.0f);
float3 z CTR3(4.0f, 5.0f, 6.0f);
#define CTR_WTF(__VA_ARGS__) = float(__VA_ARGS__)
float3 w CTR_WTF(0.0f);
#define STRING(x, ...) #__VA_ARGS__
string Bar = STRING(7, Pass, 8);
```
produces
```hlsl
float x = {0.0f};
float3 y = {1.0f, 2.0f, 3.0f};
float3 z = float3(4.0f, 5.0f, 6.0f);

float3 w = float(0.0f);

string Bar = "Pass, 8";
```