### PR TITLE
Angled includes don't lookup files hierarchy, only AdditionalIncludeDirectories.

### DIFF
--- a/src/ShaderTools.CodeAnalysis.Hlsl.EditorFeatures/OpenIncludeFile/OpenIncludeFileCommandHandler.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.EditorFeatures/OpenIncludeFile/OpenIncludeFileCommandHandler.cs
@@ -59,7 +59,7 @@ namespace ShaderTools.CodeAnalysis.Editor.Hlsl.OpenIncludeFile
 
             var currentFile = ((SyntaxTree) syntaxTree).File;
 
-            var include = includeFileResolver.OpenInclude(includeDirectiveTrivia.TrimmedFilename, currentFile);
+            var include = includeFileResolver.OpenInclude(includeDirectiveTrivia.TrimmedFilename, currentFile, includeDirectiveTrivia.IsAngled);
 
             if (include == null)
             {
@@ -67,7 +67,7 @@ namespace ShaderTools.CodeAnalysis.Editor.Hlsl.OpenIncludeFile
                 errorMessage.AppendLine($"Cannot open source file '{includeDirectiveTrivia.TrimmedFilename}'.");
                 errorMessage.AppendLine();
                 errorMessage.AppendLine("Searched paths:");
-                foreach (var includeDirectory in includeFileResolver.GetSearchDirectories(includeDirectiveTrivia.TrimmedFilename, currentFile))
+                foreach (var includeDirectory in includeFileResolver.GetSearchDirectories(includeDirectiveTrivia.TrimmedFilename, currentFile, includeDirectiveTrivia.IsAngled))
                 {
                     errorMessage.AppendLine(includeDirectory);
                 }
@@ -75,8 +75,8 @@ namespace ShaderTools.CodeAnalysis.Editor.Hlsl.OpenIncludeFile
                 context.OperationContext.TakeOwnership();
                 var notificationService = workspace.Services.GetService<INotificationService>();
                 notificationService.SendNotification(
-                    errorMessage.ToString(), 
-                    title: "Open Include File", 
+                    errorMessage.ToString(),
+                    title: "Open Include File",
                     severity: NotificationSeverity.Information);
 
                 return true;
@@ -84,7 +84,7 @@ namespace ShaderTools.CodeAnalysis.Editor.Hlsl.OpenIncludeFile
 
             var documentNavigationService = workspace.Services.GetRequiredService<IDocumentNavigationService>();
             documentNavigationService.TryNavigateToSpan(
-                workspace, 
+                workspace,
                 document.Id,
                 new SourceFileSpan(include, new TextSpan(0, 0)));
 

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Compilation/SemanticModelTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Compilation/SemanticModelTests.cs
@@ -26,10 +26,14 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Compilation
         [HlslTestSuiteData]
         public void CanGetSemanticModel(string testFile)
         {
+            var options = new HlslParseOptions();
+            if (testFile.StartsWith("TestSuite\\Shaders\\Nvidia"))
+                options.AdditionalIncludeDirectories.Add("TestSuite\\Shaders\\Nvidia");
+
             var sourceCode = File.ReadAllText(testFile);
 
             // Build syntax tree.
-            var syntaxTree = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(sourceCode), testFile), fileSystem: new TestFileSystem());
+            var syntaxTree = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(sourceCode), testFile), options, fileSystem: new TestFileSystem());
             SyntaxTreeUtility.CheckForParseErrors(syntaxTree);
 
             // Get semantic model.
@@ -134,13 +138,13 @@ typedef struct { int a; } MyStruct2;"));
 
             Assert.Equal(0, semanticModel.GetDiagnostics().Count(x => x.Severity == DiagnosticSeverity.Error));
 
-            var typedefStatement = (TypedefStatementSyntax)syntaxTree.Root.ChildNodes[0];
+            var typedefStatement = (TypedefStatementSyntax) syntaxTree.Root.ChildNodes[0];
 
             var typeAliasSymbol = semanticModel.GetDeclaredSymbol(typedefStatement.Declarators[0]);
             Assert.NotNull(typeAliasSymbol);
             Assert.Equal("MyStruct", typeAliasSymbol.Name);
 
-            var typedefStatement2 = (TypedefStatementSyntax)syntaxTree.Root.ChildNodes[1];
+            var typedefStatement2 = (TypedefStatementSyntax) syntaxTree.Root.ChildNodes[1];
 
             var typeAliasSymbol2 = semanticModel.GetDeclaredSymbol(typedefStatement2.Declarators[0]);
             Assert.NotNull(typeAliasSymbol2);

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Formatting/FormatterTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Formatting/FormatterTests.cs
@@ -162,7 +162,7 @@ void main()
 # define  BAZ(a ,  b)  a   +  b
 
 
-# include  <include.hlsli> 
+# include  ""include.hlsli"" 
 
 # undef  FOO  
 
@@ -189,7 +189,7 @@ void main()
 #define  BAZ(a ,  b)  a   +  b
 
 
-#include  <include.hlsli> 
+#include  ""include.hlsli"" 
 
 #undef  FOO  
 
@@ -1760,7 +1760,7 @@ RWBuffer<uint> BoundingBox _ : register(u2);
 ");
         }
 
-        private static void AssertFormat(string unformattedText, string expectedNewText, 
+        private static void AssertFormat(string unformattedText, string expectedNewText,
             TextSpan? textSpan = null, FormattingOptions options = null,
             Dictionary<string, string> includes = null,
             bool allowSyntaxErrors = false)

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Formatting/IdempotentTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Formatting/IdempotentTests.cs
@@ -16,18 +16,23 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Formatting
         [HlslTestSuiteData]
         public void CanFormatAndReformat(string testFile)
         {
+            var options = new HlslParseOptions();
+            if (testFile.StartsWith("TestSuite\\Shaders\\Nvidia"))
+                options.AdditionalIncludeDirectories.Add("TestSuite\\Shaders\\Nvidia");
+
             // Arrange.
             var sourceCode = File.ReadAllText(testFile);
-            var syntaxTree1 = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(sourceCode), testFile), fileSystem: new TestFileSystem());
+            var syntaxTree1 = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(sourceCode), testFile), options, fileSystem: new TestFileSystem());
+            SyntaxTreeUtility.CheckForParseErrors(syntaxTree1);
 
             // Format.
             var formattedCode1 = FormatCode(sourceCode, syntaxTree1);
-            var syntaxTree2 = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(formattedCode1), testFile), fileSystem: new TestFileSystem());
+            var syntaxTree2 = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(formattedCode1), testFile), options, fileSystem: new TestFileSystem());
             SyntaxTreeUtility.CheckForParseErrors(syntaxTree2);
 
             // Format again.
             var formattedCode2 = FormatCode(formattedCode1, syntaxTree2);
-            var syntaxTree3 = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(formattedCode2), testFile), fileSystem: new TestFileSystem());
+            var syntaxTree3 = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(formattedCode2), testFile), options, fileSystem: new TestFileSystem());
             SyntaxTreeUtility.CheckForParseErrors(syntaxTree3);
 
             Assert.Equal(formattedCode1, formattedCode2);

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Formatting/SyntaxNodeExtensionsTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Formatting/SyntaxNodeExtensionsTests.cs
@@ -6,6 +6,7 @@ using ShaderTools.CodeAnalysis.Hlsl.Syntax;
 using ShaderTools.CodeAnalysis.Hlsl.Tests.Support;
 using ShaderTools.CodeAnalysis.Hlsl.Tests.TestSuite;
 using ShaderTools.CodeAnalysis.Text;
+using ShaderTools.Testing;
 using Xunit;
 
 namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Formatting
@@ -16,12 +17,15 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Formatting
         [HlslTestSuiteData]
         public void CanGetRootLocatedNodes(string testFile)
         {
+            var options = new HlslParseOptions();
+            if (testFile.StartsWith("TestSuite\\Shaders\\Nvidia"))
+                options.AdditionalIncludeDirectories.Add("TestSuite\\Shaders\\Nvidia");
+
             var sourceCode = File.ReadAllText(testFile);
 
             // Build syntax tree.
-            var syntaxTree = SyntaxFactory.ParseSyntaxTree(
-                new SourceFile(SourceText.From(sourceCode), testFile), 
-                fileSystem: new TestFileSystem());
+            var syntaxTree = SyntaxFactory.ParseSyntaxTree(new SourceFile(SourceText.From(sourceCode), testFile), options, fileSystem: new TestFileSystem());
+            SyntaxTreeUtility.CheckForParseErrors(syntaxTree);
 
             // Check roundtripping.
             var allRootTokensAndTrivia = ((SyntaxNode) syntaxTree.Root).GetRootLocatedNodes();

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/HlslLexerTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/HlslLexerTests.cs
@@ -29,7 +29,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal(1, allTokens[0].TrailingTrivia.Length);
             Assert.Equal(new SourceRange(new SourceLocation(1), 1), allTokens[0].TrailingTrivia[0].SourceRange);
             Assert.Equal(SyntaxKind.WhitespaceTrivia, allTokens[0].TrailingTrivia[0].Kind);
-            Assert.Equal(" ", ((SyntaxTrivia)allTokens[0].TrailingTrivia[0]).Text);
+            Assert.Equal(" ", ((SyntaxTrivia) allTokens[0].TrailingTrivia[0]).Text);
 
             Assert.Equal(new SourceRange(new SourceLocation(2), 1), allTokens[1].SourceRange);
             Assert.Equal(new SourceRange(new SourceLocation(2), 3), allTokens[1].FullSourceRange);
@@ -37,21 +37,21 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
             Assert.Equal(2, allTokens[1].TrailingTrivia.Length);
             Assert.Equal(new SourceRange(new SourceLocation(3), 1), allTokens[1].TrailingTrivia[0].SourceRange);
             Assert.Equal(SyntaxKind.WhitespaceTrivia, allTokens[1].TrailingTrivia[0].Kind);
-            Assert.Equal(" ", ((SyntaxTrivia)allTokens[0].TrailingTrivia[0]).Text);
+            Assert.Equal(" ", ((SyntaxTrivia) allTokens[0].TrailingTrivia[0]).Text);
             Assert.Equal(new SourceRange(new SourceLocation(4), 1), allTokens[1].TrailingTrivia[1].SourceRange);
             Assert.Equal(SyntaxKind.EndOfLineTrivia, allTokens[1].TrailingTrivia[1].Kind);
-            Assert.Equal("\n", ((SyntaxTrivia)allTokens[1].TrailingTrivia[1]).Text);
+            Assert.Equal("\n", ((SyntaxTrivia) allTokens[1].TrailingTrivia[1]).Text);
 
             Assert.Equal(new SourceRange(new SourceLocation(6), 1), allTokens[2].SourceRange);
             Assert.Equal(new SourceRange(new SourceLocation(5), 4), allTokens[2].FullSourceRange);
             Assert.Equal(1, allTokens[2].LeadingTrivia.Length);
             Assert.Equal(new SourceRange(new SourceLocation(5), 1), allTokens[2].LeadingTrivia[0].SourceRange);
             Assert.Equal(SyntaxKind.WhitespaceTrivia, allTokens[2].LeadingTrivia[0].Kind);
-            Assert.Equal(" ", ((SyntaxTrivia)allTokens[2].LeadingTrivia[0]).Text);
+            Assert.Equal(" ", ((SyntaxTrivia) allTokens[2].LeadingTrivia[0]).Text);
             Assert.Equal(1, allTokens[2].TrailingTrivia.Length);
             Assert.Equal(new SourceRange(new SourceLocation(7), 2), allTokens[2].TrailingTrivia[0].SourceRange);
             Assert.Equal(SyntaxKind.WhitespaceTrivia, allTokens[2].TrailingTrivia[0].Kind);
-            Assert.Equal("  ", ((SyntaxTrivia)allTokens[2].TrailingTrivia[0]).Text);
+            Assert.Equal("  ", ((SyntaxTrivia) allTokens[2].TrailingTrivia[0]).Text);
 
             Assert.Equal(SyntaxKind.EndOfFileToken, allTokens[3].Kind);
             Assert.Equal(new SourceRange(new SourceLocation(9), 0), allTokens[3].SourceRange);
@@ -125,7 +125,11 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
 
         private static IReadOnlyList<SyntaxToken> LexAllTokens(SourceFile file, IIncludeFileSystem fileSystem = null)
         {
-            return SyntaxFactory.ParseAllTokens(file, fileSystem);
+            var options = new HlslParseOptions();
+            if (file.FilePath != null && file.FilePath.StartsWith("TestSuite\\Shaders\\Nvidia"))
+                options.AdditionalIncludeDirectories.Add("TestSuite\\Shaders\\Nvidia");
+
+            return SyntaxFactory.ParseAllTokens(file, options, fileSystem);
         }
 
         private static SyntaxToken LexToken(string text)

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
@@ -936,20 +936,61 @@ int a;
             const string fooText = @"
 #define DECL(n, v) int n = v
 ";
+            const string barText = @"
+#include <foo.hlsl>
+#include ""foo.hlsl""
+
+#include ""foo4.hlsl""
+#include ""foo2.hlsl""
+#include ""sub/foo3.hlsl""
+
+#define BAR 1
+";
             const string text = @"
 float foo;
 #define FOO
 #include <foo.hlsl>
+#include ""foo.hlsl""
+
+#include ""sub/sub2/bar.hlsl""
+#include ""foo2.hlsl""
+
 DECL(i, 2);
 float bar;
 ";
-            var node = Parse(text, null, new InMemoryFileSystem(new Dictionary<string, string>
-            {
-                { "foo.hlsl", fooText }
-            }));
+            var node = Parse(
+                text,
+                new HlslParseOptions
+                {
+                    AdditionalIncludeDirectories = { "test" }
+                },
+                new InMemoryFileSystem(new Dictionary<string, string>
+                {
+                    { Path.Combine("test", "foo.hlsl"), fooText },
+                    { Path.Combine("test2", "foo2.hlsl"), fooText },
+                    { Path.Combine("test2", "sub", "foo3.hlsl"), fooText },
+                    { Path.Combine("test2", "sub", "sub2", "foo4.hlsl"), fooText },
+                    { Path.Combine("test2", "sub", "sub2", "bar.hlsl"), barText }
+                }), Path.Combine("test2", "__Root__.hlsl"));
 
             TestRoundTripping(node, text);
             VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.ObjectLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
                 new DirectiveInfo { Kind = SyntaxKind.ObjectLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
                 new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
                 new DirectiveInfo { Kind = SyntaxKind.FunctionLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive });
@@ -1026,14 +1067,48 @@ float bar;
         [Fact]
         public void TestNegMissingInclude()
         {
-            const string text = @"
-#include <foo.hlsl>
+            const string fooText = @"
+#define DECL(n, v) int n = v
 ";
-            var node = Parse(text, null, new InMemoryFileSystem(new Dictionary<string, string>()));
+            const string barText = @"
+#include ""foo3.hlsl""
+
+#define BAR 1
+";
+            const string text = @"
+float foo;
+#define FOO
+#include ""sub/sub2/bar.hlsl""
+
+#include <foo4.hlsl>
+#include ""foo4.hlsl""
+
+#include <foo2.hlsl>
+";
+            var node = Parse(
+                text,
+                new HlslParseOptions
+                {
+                    AdditionalIncludeDirectories = { "test" }
+                },
+                new InMemoryFileSystem(new Dictionary<string, string>
+                {
+                    { Path.Combine("test", "foo.hlsl"), fooText },
+                    { Path.Combine("test2", "foo2.hlsl"), fooText },
+                    { Path.Combine("test2", "sub", "foo3.hlsl"), fooText },
+                    { Path.Combine("test2", "sub", "sub2", "foo4.hlsl"), fooText },
+                    { Path.Combine("test2", "sub", "sub2", "bar.hlsl"), barText }
+                }), Path.Combine("test2", "__Root__.hlsl"));
 
             TestRoundTripping(node, text, false);
-            VerifyErrorCode(node, DiagnosticId.IncludeNotFound);
+            VerifyErrorCode(node, DiagnosticId.IncludeNotFound, DiagnosticId.IncludeNotFound, DiagnosticId.IncludeNotFound, DiagnosticId.IncludeNotFound);
             VerifyDirectivesSpecial(node,
+                new DirectiveInfo { Kind = SyntaxKind.ObjectLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.ObjectLikeDefineDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
+                new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive },
                 new DirectiveInfo { Kind = SyntaxKind.IncludeDirectiveTrivia, Status = NodeStatus.IsActive });
         }
 
@@ -1097,7 +1172,7 @@ float bar;
 
             var includeResolver = new IncludeFileResolver(mockFileSystem, options);
 
-            var parsedSource = includeResolver.OpenInclude(includeDirective, sourceFile);
+            var parsedSource = includeResolver.OpenInclude(includeDirective, sourceFile, false);
 
             Assert.Equal(includedFileContents, parsedSource.Text.ToString());
         }
@@ -1128,7 +1203,7 @@ float bar;
 
             var includeResolver = new IncludeFileResolver(mockFileSystem, options);
 
-            var parsedSource = includeResolver.OpenInclude(includeDirective, sourceFile);
+            var parsedSource = includeResolver.OpenInclude(includeDirective, sourceFile, false);
 
             Assert.Equal(includedFileContents, parsedSource.Text.ToString());
         }
@@ -1162,7 +1237,7 @@ float bar;
 
             var includeResolver = new IncludeFileResolver(mockFileSystem, options);
 
-            var parsedSource = includeResolver.OpenInclude(includeDirective, sourceFile);
+            var parsedSource = includeResolver.OpenInclude(includeDirective, sourceFile, false);
 
             Assert.Equal(includedFileContents, parsedSource.Text.ToString());
         }
@@ -1174,9 +1249,9 @@ float bar;
             return SyntaxFactory.ParseAllTokens(new SourceFile(SourceText.From(text)));
         }
 
-        private static CompilationUnitSyntax Parse(string text, HlslParseOptions options = null, IIncludeFileSystem fileSystem = null)
+        private static CompilationUnitSyntax Parse(string text, HlslParseOptions options = null, IIncludeFileSystem fileSystem = null, string filePath = "__Root__.hlsl")
         {
-            return SyntaxFactory.ParseCompilationUnit(new SourceFile(SourceText.From(text), "__Root__.hlsl"), options, fileSystem);
+            return SyntaxFactory.ParseCompilationUnit(new SourceFile(SourceText.From(text), filePath), options, fileSystem);
         }
 
         private static void TestRoundTripping(CompilationUnitSyntax node, string text, bool disallowErrors = true)

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/RoundtrippingTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/RoundtrippingTests.cs
@@ -14,13 +14,14 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Tests.Parser
         [HlslTestSuiteData]
         public void CanBuildSyntaxTree(string testFile)
         {
+            var options = new HlslParseOptions();
+            if (testFile.StartsWith("TestSuite\\Shaders\\Nvidia"))
+                options.AdditionalIncludeDirectories.Add("TestSuite\\Shaders\\Nvidia");
+
             var sourceCode = File.ReadAllText(testFile);
 
             // Build syntax tree.
-            var syntaxTree = SyntaxFactory.ParseSyntaxTree(
-                new CodeAnalysis.Text.SourceFile(SourceText.From(sourceCode), testFile),
-                fileSystem: new TestFileSystem());
-
+            var syntaxTree = SyntaxFactory.ParseSyntaxTree(new CodeAnalysis.Text.SourceFile(SourceText.From(sourceCode), testFile), options, fileSystem: new TestFileSystem());
             SyntaxTreeUtility.CheckForParseErrors(syntaxTree);
 
             // Check roundtripping.

--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Syntax/SyntaxTreeTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Syntax/SyntaxTreeTests.cs
@@ -156,7 +156,7 @@ float baz;
 
             const string text = @"
 float foo;
-#include <foo.hlsl>
+#include ""foo.hlsl""
 DECL(i, 2);
 float bar;
 ";

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.cs
@@ -64,7 +64,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
             _rootFile = file;
 
             _includeFileResolver = new IncludeFileResolver(
-                includeFileSystem ?? new DummyFileSystem(), 
+                includeFileSystem ?? new DummyFileSystem(),
                 options ?? new HlslParseOptions());
 
             _directives = DirectiveStack.Empty;
@@ -161,7 +161,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
                             {
                                 foreach (var childToVisit in nodeToVisit.ChildNodes)
                                 {
-                                    VisitNode((SyntaxNode)childToVisit);
+                                    VisitNode((SyntaxNode) childToVisit);
                                 }
                             }
                         }
@@ -170,7 +170,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
                         {
                             VisitNode(originalNode);
                         }
-                        
+
                         leadingTrivia.AddRange(token.LeadingTrivia);
                         token = token.WithLeadingTrivia(leadingTrivia.ToImmutableArray());
                     }
@@ -203,7 +203,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
             _diagnostics.Clear();
             while (true)
             {
-                _leadingTrivia.Clear();                
+                _leadingTrivia.Clear();
                 _start = _charReader.Position;
                 ReadTrivia(_leadingTrivia, isTrailing: false);
                 var newLeadingTrivia = _leadingTrivia.ToImmutableArray();
@@ -321,7 +321,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
                 SourceFile include;
                 try
                 {
-                    include = _includeFileResolver.OpenInclude(includeFilename, _includeStack.Peek().File);
+                    include = _includeFileResolver.OpenInclude(includeFilename, _includeStack.Peek().File, includeDirective.IsAngled);
                     if (include == null)
                     {
                         includeDirective = includeDirective.WithDiagnostic(Diagnostic.Create(HlslMessageProvider.Instance, includeDirective.SourceRange, (int) DiagnosticId.IncludeNotFound, includeFilename));
@@ -1273,7 +1273,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
 
                 checked
                 {
-                    val += (long)(c * Math.Pow(8, j));
+                    val += (long) (c * Math.Pow(8, j));
                 }
             }
 
@@ -1303,7 +1303,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
             _kind = SyntaxFacts.GetKeywordKind(text);
 
             _contextualKind = (_mode == LexerMode.Directive)
-                ? SyntaxFacts.GetPreprocessorKeywordKind(text) 
+                ? SyntaxFacts.GetPreprocessorKeywordKind(text)
                 : SyntaxFacts.GetContextualKeywordKind(text);
 
             switch (_kind)

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/DirectiveTriviaSyntax.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/DirectiveTriviaSyntax.cs
@@ -27,5 +27,6 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
     public sealed partial class IncludeDirectiveTriviaSyntax : DirectiveTriviaSyntax
     {
         public string TrimmedFilename => Filename.Text.TrimStart('<', '"').TrimEnd('>', '"');
+        public bool IsAngled => Filename.Text.StartsWith("<");
     }
 }

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxFactory.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Syntax/SyntaxFactory.cs
@@ -54,7 +54,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
                         lexer.FileSegments);
                 });
 
-            Debug.WriteLine(DateTime.Now +  " - Finished parsing");
+            Debug.WriteLine(DateTime.Now + " - Finished parsing");
 
             return result;
         }
@@ -64,11 +64,11 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Syntax
             return new HlslLexer(new SourceFile(SourceText.From(text))).Lex(LexerMode.Syntax);
         }
 
-        public static IReadOnlyList<SyntaxToken> ParseAllTokens(SourceFile file, IIncludeFileSystem fileSystem = null)
+        public static IReadOnlyList<SyntaxToken> ParseAllTokens(SourceFile file, HlslParseOptions options = null, IIncludeFileSystem fileSystem = null)
         {
             var tokens = new List<SyntaxToken>();
 
-            var lexer = new HlslLexer(file, includeFileSystem: fileSystem);
+            var lexer = new HlslLexer(file, options, fileSystem);
             SyntaxToken token;
             do
             {

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Text/IIncludeFileResolver.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Text/IIncludeFileResolver.cs
@@ -5,7 +5,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Text
 {
     public interface IIncludeFileResolver
     {
-        ImmutableArray<string> GetSearchDirectories(string includeFilename, SourceFile currentFile);
-        SourceFile OpenInclude(string includeFilename, SourceFile currentFile);
+        ImmutableArray<string> GetSearchDirectories(string includeFilename, SourceFile currentFile, bool isAngled);
+        SourceFile OpenInclude(string includeFilename, SourceFile currentFile, bool isAngled);
     }
 }


### PR DESCRIPTION
- Added the `isAngled` boolean to `GetSearchDirectories` and `OpenInclude` methods, it skips the "looking through the hierarchy of files" logic and uses `AdditionalIncludeDirectories` instead.
- It also still allows the "rooted path", because I'm not sure its valid for real applications, so I keep it for editor purposes.
- `IncludeDirectiveTriviaSyntax` now has `IsAngled` boolean that indicates whether the directive uses angled brackets `<file.hlsli>`.
- PreprocessorTests's `Parse` function can override the `filePath` of `SourceFile`.
- Huge test for quoted and angled includes + negative test with wrong usage. Correlates with the latest DXC release again.
- There is lots of test shaders in "TestSuite\\Shaders\\Nvidia" uses angled brackets, so I had to add `AdditionalIncludeDirectories` in all tests, but only for Nvidia cases.

I'm also looking at #131 and trying to figure out what it does. It has an `IncludeType` enum with "local" type (oh hey is it angled includes yeas?), but the code doesn't do anything - its just passes arguments and types, but the logic wasn't changed.

example
```hlsl
AdditionalIncludeDirectories = { "SystemAddInclude" }

SystemAddInclude:
	Global.hlsli

Shaders:
	header.hlsli
	object.hlsl:
		#include "Global.hlsli" // valid
		#include <Global.hlsli> // valid
		#include "header.hlsli" // valid
		#include <header.hlsli> // error
```