### PR TITLE
Line directive has optional filename argument.

### DIFF
--- a/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl.Tests/Parser/PreprocessorTests.cs
@@ -874,13 +874,19 @@ int a;
         public void TestLine()
         {
             const string text = @"
+#line 190
 #line 3 ""a\path\to.hlsl""
-";
+#line 8
+
+#line 30";
             var node = Parse(text);
 
             TestRoundTripping(node, text);
             VerifyDirectivesSpecial(node,
-                new DirectiveInfo { Kind = SyntaxKind.LineDirectiveTrivia, Status = NodeStatus.IsActive, Number = 3, Text = @"a\path\to.hlsl" });
+                new DirectiveInfo { Kind = SyntaxKind.LineDirectiveTrivia, Status = NodeStatus.IsActive, Number = 190 },
+                new DirectiveInfo { Kind = SyntaxKind.LineDirectiveTrivia, Status = NodeStatus.IsActive, Number = 3, Text = @"a\path\to.hlsl" },
+                new DirectiveInfo { Kind = SyntaxKind.LineDirectiveTrivia, Status = NodeStatus.IsActive, Number = 8 },
+                new DirectiveInfo { Kind = SyntaxKind.LineDirectiveTrivia, Status = NodeStatus.IsActive, Number = 30 });
         }
 
         [Fact]
@@ -1305,36 +1311,12 @@ float bar;
                     case SyntaxKind.LineDirectiveTrivia:
                         var ld = dt as LineDirectiveTriviaSyntax;
 
-                        // default number = 0 - no number
-                        if (exp.Number == -1)
-                        {
-                            Assert.Equal(SyntaxKind.LineKeyword, ld.LineKeyword.Kind);
-                            Assert.Equal(SyntaxKind.DefaultKeyword, ld.Line.Kind);
-                        }
-                        else if (exp.Number == -2)
-                        {
-                            Assert.Equal(SyntaxKind.LineKeyword, ld.LineKeyword.Kind);
-                            //Assert.Equal(SyntaxKind.HiddenKeyword, ld.Line.Kind);
-                        }
-                        else if (exp.Number == 0)
-                        {
-                            Assert.Equal(String.Empty, ld.Line.Text);
-                        }
-                        else if (exp.Number > 0)
-                        {
-                            Assert.Equal(exp.Number, ld.Line.Value); // Number
-                            Assert.Equal(exp.Number, Int32.Parse(ld.Line.Text));
-                        }
+                        Assert.True(exp.Number >= 0);
+                        Assert.Equal(exp.Number, ld.Line.Value); // Number
+                        Assert.Equal(exp.Number, Int32.Parse(ld.Line.Text));
 
-                        if (null == exp.Text)
-                        {
-                            Assert.Equal(SyntaxKind.None, ld.File.Kind);
-                        }
-                        else
-                        {
-                            Assert.NotEqual(SyntaxKind.None, ld.File.Kind);
-                            Assert.Equal(exp.Text, ld.File.Value);
-                        }
+                        Assert.NotEqual(SyntaxKind.None, ld.File.Kind);
+                        Assert.Equal(exp.Text, ld.File.Value);
 
                         break;
                 } // switch

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Diagnostics/DiagnosticId.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Diagnostics/DiagnosticId.cs
@@ -21,7 +21,6 @@
         AlreadyDefined,
         BadDirectivePlacement,
         EndOfPreprocessorLineExpected,
-        MissingPreprocessorFile,
         IncludeNotFound,
         IncludeUnexpectedError,
         NotEnoughMacroParameters,

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Parser/DirectiveParser.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Parser/DirectiveParser.cs
@@ -268,7 +268,9 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
         private LineDirectiveTriviaSyntax ParseLineDirective(SyntaxToken hash, SyntaxToken keyword, bool isActive)
         {
             var line = Match(SyntaxKind.IntegerLiteralToken);
-            var filename = Match(SyntaxKind.StringLiteralToken);
+            var filename = Current.Kind != SyntaxKind.EndOfDirectiveToken ? Match(SyntaxKind.StringLiteralToken) : new SyntaxToken(SyntaxKind.EndOfDirectiveToken, true,
+                GetDiagnosticSourceRangeForMissingToken(),
+                GetDiagnosticTextSpanForMissingToken());
             var eod = ParseEndOfDirective(line.IsMissing || !isActive);
 
             return new LineDirectiveTriviaSyntax(hash, keyword, line, filename, eod, isActive);
@@ -437,7 +439,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
             return new ParenthesizedExpressionSyntax(openParen, expression, closeParen);
         }
 
-        private SyntaxToken ParseEndOfDirective(bool ignoreErrors, bool afterLineNumber = false)
+        private SyntaxToken ParseEndOfDirective(bool ignoreErrors)
         {
             var skippedTokens = new List<SyntaxToken>();
 
@@ -448,13 +450,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
                 skippedTokens = new List<SyntaxToken>(10);
 
                 if (!ignoreErrors)
-                {
-                    var errorCode = DiagnosticId.EndOfPreprocessorLineExpected;
-                    if (afterLineNumber)
-                        errorCode = DiagnosticId.MissingPreprocessorFile;
-
-                    skippedTokens.Add(WithDiagnostic(NextToken().WithoutDiagnostics(), errorCode));
-                }
+                    skippedTokens.Add(WithDiagnostic(NextToken().WithoutDiagnostics(), DiagnosticId.EndOfPreprocessorLineExpected));
 
                 while (Current.Kind != SyntaxKind.EndOfDirectiveToken &&
                        Current.Kind != SyntaxKind.EndOfFileToken)
@@ -492,9 +488,9 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
         {
             var result = Evaluate(expr);
             if (result is bool)
-                return (bool)result;
+                return (bool) result;
             if (result is int)
-                return (int)result != 0;
+                return (int) result != 0;
 
             return false;
         }
@@ -503,7 +499,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
         {
             var result = Evaluate(expr);
             if (result is int)
-                return (int)result;
+                return (int) result;
 
             return 0;
         }
@@ -516,49 +512,49 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
             switch (expr.Kind)
             {
                 case SyntaxKind.ParenthesizedExpression:
-                    return Evaluate(((ParenthesizedExpressionSyntax)expr).Expression);
+                    return Evaluate(((ParenthesizedExpressionSyntax) expr).Expression);
                 case SyntaxKind.TrueLiteralExpression:
                 case SyntaxKind.FalseLiteralExpression:
                 case SyntaxKind.NumericLiteralExpression:
-                    return ((LiteralExpressionSyntax)expr).Token.Value;
+                    return ((LiteralExpressionSyntax) expr).Token.Value;
                 case SyntaxKind.LogicalAndExpression:
                 case SyntaxKind.BitwiseAndExpression:
-                    return EvaluateBool(((BinaryExpressionSyntax)expr).Left) && EvaluateBool(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateBool(((BinaryExpressionSyntax) expr).Left) && EvaluateBool(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.LogicalOrExpression:
                 case SyntaxKind.BitwiseOrExpression:
-                    return EvaluateBool(((BinaryExpressionSyntax)expr).Left) || EvaluateBool(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateBool(((BinaryExpressionSyntax) expr).Left) || EvaluateBool(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.EqualsExpression:
-                    return Equals(Evaluate(((BinaryExpressionSyntax)expr).Left), Evaluate(((BinaryExpressionSyntax)expr).Right));
+                    return Equals(Evaluate(((BinaryExpressionSyntax) expr).Left), Evaluate(((BinaryExpressionSyntax) expr).Right));
                 case SyntaxKind.NotEqualsExpression:
-                    return !Equals(Evaluate(((BinaryExpressionSyntax)expr).Left), Evaluate(((BinaryExpressionSyntax)expr).Right));
+                    return !Equals(Evaluate(((BinaryExpressionSyntax) expr).Left), Evaluate(((BinaryExpressionSyntax) expr).Right));
                 case SyntaxKind.LogicalNotExpression:
-                    return !EvaluateBool(((PrefixUnaryExpressionSyntax)expr).Operand);
+                    return !EvaluateBool(((PrefixUnaryExpressionSyntax) expr).Operand);
                 case SyntaxKind.AddExpression:
-                    return EvaluateInt(((BinaryExpressionSyntax)expr).Left) + EvaluateInt(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateInt(((BinaryExpressionSyntax) expr).Left) + EvaluateInt(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.SubtractExpression:
-                    return EvaluateInt(((BinaryExpressionSyntax)expr).Left) - EvaluateInt(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateInt(((BinaryExpressionSyntax) expr).Left) - EvaluateInt(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.MultiplyExpression:
-                    return EvaluateInt(((BinaryExpressionSyntax)expr).Left) * EvaluateInt(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateInt(((BinaryExpressionSyntax) expr).Left) * EvaluateInt(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.DivideExpression:
                     var divisor = EvaluateInt(((BinaryExpressionSyntax) expr).Right);
                     return (divisor != 0)
                         ? EvaluateInt(((BinaryExpressionSyntax) expr).Left) / divisor
                         : int.MaxValue;
                 case SyntaxKind.GreaterThanExpression:
-                    return EvaluateInt(((BinaryExpressionSyntax)expr).Left) > EvaluateInt(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateInt(((BinaryExpressionSyntax) expr).Left) > EvaluateInt(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.GreaterThanOrEqualExpression:
-                    return EvaluateInt(((BinaryExpressionSyntax)expr).Left) >= EvaluateInt(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateInt(((BinaryExpressionSyntax) expr).Left) >= EvaluateInt(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.LessThanExpression:
-                    return EvaluateInt(((BinaryExpressionSyntax)expr).Left) < EvaluateInt(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateInt(((BinaryExpressionSyntax) expr).Left) < EvaluateInt(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.LessThanOrEqualExpression:
-                    return EvaluateInt(((BinaryExpressionSyntax)expr).Left) <= EvaluateInt(((BinaryExpressionSyntax)expr).Right);
+                    return EvaluateInt(((BinaryExpressionSyntax) expr).Left) <= EvaluateInt(((BinaryExpressionSyntax) expr).Right);
                 case SyntaxKind.IdentifierName:
-                    var id = ((IdentifierNameSyntax)expr).Name.Text;
+                    var id = ((IdentifierNameSyntax) expr).Name.Text;
                     return IsDirectiveDefined(id);
                 case SyntaxKind.FunctionInvocationExpression:
                     // It must be a call to "defined" - that's the only one allowed by the parser.
-                    var functionCall = (FunctionInvocationExpressionSyntax)expr;
-                    var identifierName = ((IdentifierNameSyntax)functionCall.ArgumentList.Arguments[0]).Name;
+                    var functionCall = (FunctionInvocationExpressionSyntax) expr;
+                    var identifierName = ((IdentifierNameSyntax) functionCall.ArgumentList.Arguments[0]).Name;
                     return IsDirectiveDefined(identifierName.Text);
                 default:
                     return false;

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.Preprocessor.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Parser/HlslLexer.Preprocessor.cs
@@ -24,7 +24,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
         {
             _kind = SyntaxKind.BadToken;
             _contextualKind = SyntaxKind.BadToken;
-
+            _value = null;
             _diagnostics.Clear();
             _start = _charReader.Position;
 
@@ -82,7 +82,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Parser
 
             LexDirectiveTrailingTrivia(trailingTrivia, kind, isEndOfLine);
 
-            var token = new SyntaxToken(kind, _contextualKind, false, MakeAbsolute(span), fileSpan, text, _value, 
+            var token = new SyntaxToken(kind, _contextualKind, false, MakeAbsolute(span), fileSpan, text, _value,
                 ImmutableArray<SyntaxNode>.Empty, trailingTrivia.ToImmutableArray(),
                 diagnostics, null, false);
 

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Properties/Resources.Designer.cs
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -363,15 +363,6 @@ namespace ShaderTools.CodeAnalysis.Hlsl.Properties {
         internal static string MethodOverloadResolutionFailure {
             get {
                 return ResourceManager.GetString("MethodOverloadResolutionFailure", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Quoted file name, single-line comment or end-of-line expected..
-        /// </summary>
-        internal static string MissingPreprocessorFile {
-            get {
-                return ResourceManager.GetString("MissingPreprocessorFile", resourceCulture);
             }
         }
         

--- a/src/ShaderTools.CodeAnalysis.Hlsl/Properties/Resources.resx
+++ b/src/ShaderTools.CodeAnalysis.Hlsl/Properties/Resources.resx
@@ -213,9 +213,6 @@
   <data name="MethodOverloadResolutionFailure" xml:space="preserve">
     <value>No overload for method '{0}' takes {1} arguments.</value>
   </data>
-  <data name="MissingPreprocessorFile" xml:space="preserve">
-    <value>Quoted file name, single-line comment or end-of-line expected.</value>
-  </data>
   <data name="NotEnoughMacroParameters" xml:space="preserve">
     <value>Not enough actual parameters for macro '{0}'.</value>
   </data>


### PR DESCRIPTION
- Filename string argument in the line directive is optional https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-appendix-pre-line
- If this happens then in `ParseLineDirective` I create the missing token `EndOfDirectiveToken`. I'm not sure if its ok, but it works.
- `HlslLexer.LexDirectiveToken` must reset his value `_value = null;` before parsing, like `HlslLexer.LexSyntaxToken`. Because some directives have no value and it extrapolates the previous one to next - bad.
- Removing `afterLineNumber` argument from `ParseEndOfDirective`. It looks like a special error for the line directive, it referred to `MissingPreprocessorFile` but was never used.
- Added a test for `#line` without filename, it also checking if the end of directive is parsed correctly.
- Fix test checking for `LineDirectiveTrivia` kind. No more special cases for 0, -1, -2 line number. It just should be >= 0. Yes, correlates with the latest DXC release!


```hlsl
#line 10 "file.hlsl"  // valid
#line 20              // valid too
```